### PR TITLE
Install headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+/example/cysignals_example.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
 
 script:
   - python -m doctest src/cysignals/*.pyx
+  - cd example && python setup.py install
 
 notifications:
   on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script:
   - python -m doctest src/cysignals/*.pyx
-  - cd example && python setup.py install
+  - cd example && python setup.py build
 
 notifications:
   on_success: change

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ distclean: clean
 
 check: install
 	$(PYTHON) -m doctest src/cysignals/*.pyx
+	cd example && python setup.py build
 
 test: check
 

--- a/example/README
+++ b/example/README
@@ -1,0 +1,1 @@
+This is a complete working example package using cysignals.

--- a/example/cysignals_example.pyx
+++ b/example/cysignals_example.pyx
@@ -1,0 +1,10 @@
+include "cysignals/signals.pxi"
+
+from libc.math cimport sin
+
+def sine_sum(double x, long count):
+    cdef double s = 0
+    for i in range(count):
+        sig_check()
+        s += sin(i*x)
+    return s

--- a/example/setup.py
+++ b/example/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-from distutils.extension import Extension
 from Cython.Build import cythonize
-
+import sys
 
 # Run Cython
-extensions=cythonize("cysignals_example.pyx")
+extensions=cythonize("cysignals_example.pyx", include_path=sys.path)
 
 # Run Distutils
 setup(

--- a/example/setup.py
+++ b/example/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+
+
+# Run Cython
+extensions=cythonize("cysignals_example.pyx")
+
+# Run Distutils
+setup(
+    name="cysignals_example",
+    version='1.0',
+    ext_modules=extensions,
+    license='GNU General Public License, version 2 or later',
+)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from distutils.core import setup
+from distutils.command.build_py import build_py
 from distutils.extension import Extension
+from distutils.sysconfig import get_python_lib
 from Cython.Build import cythonize
 
 import os
-import sys
-import sysconfig
 from glob import glob
 
 opj = os.path.join
@@ -40,7 +40,8 @@ try:
     os.makedirs(opj(cythonize_dir, "src", "cysignals"))
 except OSError:
     pass
-install_dir = opj(sysconfig.get_path("platlib"), "cysignals")
+
+install_dir = opj(get_python_lib(), "cysignals")
 with open(opj(cythonize_dir, "src", "cysignals", "__init__.pxd"), "wt") as f:
     f.write("# distutils: include_dirs = {0}\n".format(install_dir))
 
@@ -51,7 +52,6 @@ extensions=cythonize(extensions, build_dir=cythonize_dir,
 
 
 # Run Distutils
-from distutils.command.build_py import build_py
 class build_py_cython(build_py):
     """
     Custom distutils build_py class. For every package FOO, we also

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from Cython.Build import cythonize
 
 import os
 import sys
+import sysconfig
 from glob import glob
 
 opj = os.path.join
@@ -33,9 +34,20 @@ extensions = [
     Extension("tests", ["src/cysignals/tests.pyx"], **kwds)
 ]
 
+
+# Add an __init__.pxd file setting the correct include path
+try:
+    os.makedirs(opj(cythonize_dir, "src", "cysignals"))
+except OSError:
+    pass
+install_dir = opj(sysconfig.get_path("platlib"), "cysignals")
+with open(opj(cythonize_dir, "src", "cysignals", "__init__.pxd"), "wt") as f:
+    f.write("# distutils: include_dirs = {0}\n".format(install_dir))
+
+
 # Run Cython
 extensions=cythonize(extensions, build_dir=cythonize_dir,
-                     include_path=["src"])
+                     include_path=["src", opj(cythonize_dir, "src")])
 
 
 # Run Distutils
@@ -79,7 +91,7 @@ setup(
     package_dir={"cysignals": opj("src", "cysignals"),
                  "cysignals-cython": opj(cythonize_dir, "src", "cysignals")},
     package_data={"cysignals": ["*.pxi", "*.pxd", "*.h"],
-                  "cysignals-cython": ["*.h"]},
+                  "cysignals-cython": ["__init__.pxd", "*.h"]},
     scripts=glob(opj("src", "scripts", "*")),
     cmdclass=dict(build_py=build_py_cython),
     license='GNU General Public License, version 2 or later',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+from distutils.core import setup, Distribution
 from distutils.command.build_py import build_py
 from distutils.extension import Extension
 from distutils.sysconfig import get_python_lib
@@ -35,13 +35,17 @@ extensions = [
 ]
 
 
+# Determine installation directory from distutils
+inst = Distribution().get_command_obj("install")
+inst.finalize_options()
+install_dir = opj(inst.install_platlib, "cysignals")
+
+
 # Add an __init__.pxd file setting the correct include path
 try:
     os.makedirs(opj(cythonize_dir, "src", "cysignals"))
 except OSError:
     pass
-
-install_dir = opj(get_python_lib(), "cysignals")
 with open(opj(cythonize_dir, "src", "cysignals", "__init__.pxd"), "wt") as f:
     f.write("# distutils: include_dirs = {0}\n".format(install_dir))
 

--- a/src/cysignals/signals.pxi
+++ b/src/cysignals/signals.pxi
@@ -1,3 +1,6 @@
+# Auto-generated file setting the correct include directories
+cimport cysignals
+
 from cysignals.signals cimport *
 
 cdef extern from 'pxi.h':


### PR DESCRIPTION
Install all header files in `site-packages/cysignals`. Add an auto-generated `__init__.pxd` file which uses `# distutils` declarations to set up the correct include paths automatically.

While this does make the `setup.py` complicated, it has some important advantages:
1. No hassle at all for packages using `cysignals`: `include "cysignals/signals.pxi"` just works.
2. Keep source directory clean: all auto-generated files live in `build`.

Assumes https://github.com/cython/cython/pull/483