### PR TITLE
Enhance helper handling in cysignals-CSI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,13 @@ setup(
     platforms=["POSIX"],
 
     ext_modules=extensions,
-    packages=["cysignals"],
+    packages=["cysignals","cysignals_gdb"],
     package_dir={"cysignals": opj("src", "cysignals"),
-                 "cysignals-cython": opj(cythonize_dir, "src", "cysignals")},
+                 "cysignals-cython": opj(cythonize_dir, "src", "cysignals"),
+                 "cysignals_gdb": opj("src", "scripts")},
     package_data={"cysignals": ["*.pxi", "*.pxd", "*.h"],
-                  "cysignals-cython": ["__init__.pxd", "*.h"]},
-    scripts=glob(opj("src", "scripts", "*")),
+                  "cysignals-cython": ["__init__.pxd", "*.h"],
+                  "cysignals_gdb": ["cysignals-CSI-helper.py"]},
+    scripts=[opj("src", "scripts", "cysignals-CSI")],
     cmdclass=dict(build_py=build_py_cython),
 )

--- a/src/scripts/__init__.py
+++ b/src/scripts/__init__.py
@@ -1,0 +1,1 @@
+# empty file

--- a/src/scripts/cysignals-CSI
+++ b/src/scripts/cysignals-CSI
@@ -64,6 +64,8 @@ def pid_exists(pid):
 
 
 def gdb_commands(pid, color):
+    from cysignals_gdb import __file__ as cysignals_gdb_pkg_root
+    cysignals_gdb_pkg_root = os.path.dirname(cysignals_gdb_pkg_root)
     cmds = b('')
     cmds += b('set prompt (cysignals-gdb-prompt)\n')
     cmds += b('set verbose off\n')
@@ -75,7 +77,7 @@ def gdb_commands(pid, color):
     cmds += b('import sys; sys.stdout.flush()\n')
     cmds += b('end\n')
     cmds += b('bt full\n')
-    script = os.path.join(os.path.dirname(sys.argv[0]), 'cysignals-CSI-helper.py')
+    script = os.path.join(cysignals_gdb_pkg_root, 'cysignals-CSI-helper.py')
     with open(script, 'r') as f:
         cmds += b('python\n')
         cmds += b('color = {0}\n'.format(color))


### PR DESCRIPTION
This patch avoid to install the helper Python include script in the
/usr/bin directory, given that installing non executable files in
this directory is highly not recommended.
