### PR TITLE
Make localisation of libpython more robust

### DIFF
--- a/src/scripts/cysignals-CSI
+++ b/src/scripts/cysignals-CSI
@@ -94,7 +94,7 @@ def run_gdb(pid, color):
     Execute gdb.
     """
     # Preload the right Python library
-    libpython = os.path.join(sysconfig.get_config_var('exec_prefix'), 'lib',
+    libpython = os.path.join(sysconfig.get_config_var('LIBDIR'),
                              sysconfig.get_config_var('INSTSONAME'))
     env = dict(os.environ)
     if sys.platform == 'macosx':


### PR DESCRIPTION
The current code makes an assumption on the name of the directory where `libpython` is located. It could vary depending on distributions or installation. The correct variable to query is `LIBDIR`.