### PR TITLE
Increase FD_SETSIZE from its default of 64 on Cygwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ cythonize_dir = "build"
 macros = []
 
 if sys.platform == 'cygwin':
+    # On Cygwin FD_SETSIZE defaults to a rather low 64; we set it higher
+    # for use with PSelecter
+    # See https://github.com/sagemath/cysignals/pull/57
     macros.append(('FD_SETSIZE', 512))
 
 kwds = dict(include_dirs=[opj("src", "cysignals"),

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,16 @@ opj = os.path.join
 
 
 cythonize_dir = "build"
+macros = []
+
+if sys.platform == 'cygwin':
+    macros.append(('FD_SETSIZE', 512))
 
 kwds = dict(include_dirs=[opj("src", "cysignals"),
                           opj(cythonize_dir, "src"),
                           opj(cythonize_dir, "src", "cysignals")],
-            depends=glob(opj("src", "cysignals", "*.h")))
+            depends=glob(opj("src", "cysignals", "*.h")),
+            define_macros=macros)
 
 extensions = [
     Extension("cysignals.signals", ["src/cysignals/signals.pyx"], **kwds),


### PR DESCRIPTION
This is basically the same problem that [tso-22839](https://trac.sagemath.org/ticket/22839) is addressing, but applied to Cysignals (specifically the pselect module).  It's necessarily to manually bump up `FD_SETSIZE` to something reasonable, and ISTM the easiest way to do that consistently, especially with Cython, is to pass it at build time.

This came up in Sage when running `./sage -t` with a large number of processes.