### PR TITLE
testgdb.py is not currently distributed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-include README README.rst VERSION LICENSE
 global-include Makefile configure configure.ac
-global-include setup.py rundoctests.py *.pyx
+global-include setup.py rundoctests.py testgdb.py *.pyx
 graft src
 graft docs/source
 prune build


### PR DESCRIPTION
As it says, the file testgdb.py is not currently included when you produce a tarball. Which means that `make check-gdb` cannot be run from the produced tar.gz.