### PR TITLE
add Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,21 @@ extensions = [
     Extension("cysignals.pselect", ["src/cysignals/pselect.pyx"], **kwds),
     Extension("cysignals.tests", ["src/cysignals/tests.pyx"], **kwds),
 ]
+classifiers = [
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Developers',
+    ('License :: OSI Approved :: '
+     'GNU Lesser General Public License v3 or later (LGPLv3+)'),
+    'Operating System :: POSIX',
+    'Programming Language :: Cython',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Topic :: Software Development']
 
 
 def write_if_changed(filename, text):
@@ -197,7 +212,6 @@ setup(
     license="GNU Lesser General Public License, version 3 or later",
     description="Interrupt and signal handling for Cython",
     long_description=open('README.rst').read(),
-    platforms=["POSIX"],
     setup_requires=["Cython"],
 
     ext_modules=extensions,
@@ -207,5 +221,6 @@ setup(
     package_data={"cysignals": ["*.pxi", "*.pxd", "*.h"],
                   "cysignals-cython": ["*.h"]},
     scripts=glob(opj("src", "scripts", "*")),
-    cmdclass=dict(build=build, build_py=build_py, install=install, bdist_egg=no_egg)
+    cmdclass=dict(build=build, build_py=build_py, install=install, bdist_egg=no_egg),
+    classifiers=classifiers,
 )


### PR DESCRIPTION
As of `cysignals == 1.6.5`, the POSIX requirement is [invisible on PyPI](https://pypi.org/project/cysignals/1.6.5/). Based on [this discussion](https://stackoverflow.com/a/34994245/1959808), `pip` is unaware of what value the `platforms` argument has (e.g., `pip show -v cysignals`):

https://github.com/sagemath/cysignals/blob/acc2ba9fcf8ffa3db1c0f1cf0da8deae7035f41d/setup.py#L200

Moreover, the [Trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) `Operating System :: POSIX` is suitable in this case, so following [PEP 345](https://www.python.org/dev/peps/pep-0345/#platform-multiple-use), the argument `platforms` can be omitted.

My choice of "development status" was nearly arbitrary; it probably needs to be adjusted.