### PR TITLE
Cysignals for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,23 @@ environment:
     # http://www.appveyor.com/docs/installed-software#python
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
-    - os: Cygwin
+    - OS: Windows_NT
+      PYTHON: "C:\\Python27-x64"
+      TOOLSPATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"
+      MAKE: mingw32-make
+    - OS: Windows_NT
+      PYTHON: "C:\\Python36-x64"
+      TOOLSPATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"
+      MAKE: mingw32-make
+    - OS: Windows_NT
+      PYTHON: "C:\\Python27"
+      TOOLSPATH: "C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"
+      MAKE: make
+    - OS: Windows_NT
+      PYTHON: "C:\\Python36"
+      TOOLSPATH: "C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"
+      MAKE: make
+    - OS: Cygwin
       CYG_ROOT: "C:\\cygwin64"
       PYTHON: "C:\\cygwin64\\bin"
       PYTHON_VERSION: "2.7"
@@ -44,5 +60,5 @@ build_script:
   - '%MAKE% -j4 install'
 
 test_script:
-  - '%MAKE% -j4 check-all'
+  - '%MAKE% -j1 check-all'
   - '%MAKE% -j4 distcheck'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-include README README.rst VERSION LICENSE
 global-include Makefile configure configure.ac
-global-include setup.py rundoctests.py testgdb.py *.pyx
+global-include setup.py rundoctests.py testgdb.py *.pyx winutil/patchdistutils.py
 graft src
 graft docs/source
 prune build

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ PYTHON = python
 PIP = $(PYTHON) -m pip -v
 LS_R = ls -Ra1
 
+ifeq ($(OS),Windows_NT)
+    LOC_SITE_PACKAGE = local/Lib/site-packages
+    BUILD_LOCAL = "build$(subst c:/,/,$(subst C:/,/,$(subst /c/,/,$(CURDIR)/tmp)))/local"
+else
+    LOC_SITE_PACKAGE = local/lib*/python*/site-packages
+    BUILD_LOCAL = "build/`pwd`/local"
+endif
+
 # We add ulimit -s 1024 in this Makefile to work around a very strange
 # OS X bug manifesting itself with Python 3 and old versions of GNU make.
 # This was discovered at https://github.com/sagemath/cysignals/issues/71
@@ -41,7 +49,7 @@ clean: clean-doc clean-build
 	rm -rf tmp
 
 clean-build:
-	rm -rf build example/build example/*.cpp
+	rm -rf build example/build example/*.cpp winutil/*.pyc winutil/__pycache__
 
 clean-doc:
 	rm -rf docs/build
@@ -92,8 +100,8 @@ check-tmp:
 prefix-install: configure
 	rm -rf tmp/local tmp/build tmp/site-packages
 	$(PYTHON) setup.py install --prefix="`pwd`/tmp/local" --root=tmp/build
-	cd tmp && mv "build/`pwd`/local" local
-	cd tmp && cp -R local/lib*/python*/site-packages site-packages
+	cd tmp && mv $(BUILD_LOCAL) local
+	cd tmp && cp -R $(LOC_SITE_PACKAGE) site-packages
 
 check-prefix: check-prefix-doctest check-prefix-example
 

--- a/example/cysignals_example.pyx
+++ b/example/cysignals_example.pyx
@@ -1,5 +1,7 @@
 # distutils: language = c++
 # cython: language_level = 3
+# The next line works around https://github.com/python/cpython/pull/880
+# distutils: define_macros = _hypot=hypot
 
 from cysignals.signals cimport sig_check
 from cysignals.memory cimport check_allocarray

--- a/example/setup.py
+++ b/example/setup.py
@@ -1,7 +1,20 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from setuptools.extension import Extension
 from distutils.command.build import build as _build
+import sys
+import os
+
+# if on windows platform, patch distutils lib.
+if sys.platform == "win32":
+    utils_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'winutil')
+    sys.path.append(utils_path)
+    from patchdistutils import runtime_patch
+    runtime_patch()
+
+extensions = [Extension('cysignals_example',
+                        ['cysignals_example.pyx'])]
 
 
 class build(_build):
@@ -22,6 +35,6 @@ setup(
     version='1.0',
     license='Public Domain',
     setup_requires=["cysignals"],
-    ext_modules=["cysignals_example.pyx"],
+    ext_modules=extensions,
     cmdclass=dict(build=build),
 )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,16 @@ if sys.platform == 'cygwin':
 # false positives in the longjmp() check.
 undef_macros = ["_FORTIFY_SOURCE"]
 
+scripts = []
+data_files = []
+
+# if on windows platform, patch distutils lib.
+if sys.platform == "win32":
+    utilspath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'winutil')
+    sys.path.append(utilspath)
+    from patchdistutils import runtime_patch
+    runtime_patch()
+
 kwds = dict(include_dirs=[opj("src"),
                           opj("src", "cysignals")],
             depends=depends,
@@ -53,12 +63,18 @@ kwds = dict(include_dirs=[opj("src"),
 
 extensions = [
     Extension("cysignals.signals", ["src/cysignals/signals.pyx"], **kwds),
-    Extension("cysignals.pysignals", ["src/cysignals/pysignals.pyx"], **kwds),
-    Extension("cysignals.alarm", ["src/cysignals/alarm.pyx"], **kwds),
-    Extension("cysignals.pselect", ["src/cysignals/pselect.pyx"], **kwds),
-    Extension("cysignals.tests", ["src/cysignals/tests.pyx"], **kwds),
+    Extension("cysignals.tests", ["src/cysignals/tests.pyx"], **kwds)
 ]
 
+if sys.platform != 'win32':
+    extensions.extend([
+        Extension("cysignals.pysignals", ["src/cysignals/pysignals.pyx"], **kwds),
+        Extension("cysignals.alarm", ["src/cysignals/alarm.pyx"], **kwds),
+        Extension("cysignals.pselect", ["src/cysignals/pselect.pyx"], **kwds),
+    ])
+
+    scripts = glob(opj("src", "scripts", "cysignals-CSI"))
+    data_files = [(opj("share", "cysignals"), [opj("src", "scripts", "cysignals-CSI-helper.py")])]
 
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -129,7 +145,7 @@ with open('README.rst') as f:
 
 setup(
     name="cysignals",
-    author=u"Martin R. Albrecht, François Bissey, Volker Braun, Jeroen Demeyer",
+    author=u"Martin R. Albrecht, François Bissey, Volker Braun, Jeroen Demeyer, Vincent Klein",
     author_email="sage-devel@googlegroups.com",
     version=VERSION,
     url="https://github.com/sagemath/cysignals",
@@ -144,7 +160,7 @@ setup(
     packages=["cysignals"],
     package_dir={"cysignals": opj("src", "cysignals")},
     package_data={"cysignals": ["*.pxi", "*.pxd", "*.h"]},
-    data_files=[(opj("share", "cysignals"), [opj("src", "scripts", "cysignals-CSI-helper.py")])],
-    scripts=glob(opj("src", "scripts", "cysignals-CSI")),
+    data_files=data_files,
+    scripts=scripts,
     cmdclass=dict(build=build, bdist_egg=no_egg),
 )

--- a/src/cysignals/cysignals_config.h.in
+++ b/src/cysignals/cysignals_config.h.in
@@ -28,3 +28,16 @@
 #define cysetjmp(env) setjmp(env)
 #define cylongjmp(env, val) longjmp(env, val)
 #endif
+
+#if !defined(__MINGW32__) && !defined(_WIN32)
+#define POSIX
+#else
+/*
+define unused signals for windows and give each a different value to compile
+when two or more a these signals are used in the same switch.
+*/
+#define SIGHUP SIGTERM
+#define SIGBUS SIGSEGV
+#define SIGALRM SIGINT
+#define SIGQUIT SIGTERM
+#endif

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -7,6 +7,8 @@ See ``tests.pyx`` for extensive tests.
 
 #*****************************************************************************
 #       Copyright (C) 2011-2018 Jeroen Demeyer <J.Demeyer@UGent.be>
+#                     2016 Marc Culler and Nathan Dunfield
+#                     2018 Vincent Klein <vinklein@gmail.com>
 #
 #  cysignals is free software: you can redistribute it and/or modify it
 #  under the terms of the GNU Lesser General Public License as published
@@ -86,8 +88,8 @@ class AlarmInterrupt(KeyboardInterrupt):
     EXAMPLES::
 
         >>> from cysignals import AlarmInterrupt
-        >>> from signal import alarm
-        >>> try:
+        >>> from signal import alarm    # doctest: +SKIP_WINDOWS
+        >>> try:                        # doctest: +SKIP_WINDOWS
         ...     _ = alarm(1)
         ...     while True:
         ...         pass
@@ -96,7 +98,7 @@ class AlarmInterrupt(KeyboardInterrupt):
         alarm!
         >>> from cysignals.signals import sig_print_exception
         >>> import signal
-        >>> sig_print_exception(signal.SIGALRM)
+        >>> sig_print_exception(signal.SIGALRM)  # doctest: +SKIP_WINDOWS
         AlarmInterrupt
 
     """
@@ -188,7 +190,7 @@ def sig_print_exception(sig, msg=None):
         >>> import signal
         >>> sig_print_exception(signal.SIGFPE)
         FloatingPointError: Floating point exception
-        >>> sig_print_exception(signal.SIGBUS, "CUSTOM MESSAGE")
+        >>> sig_print_exception(signal.SIGBUS, "CUSTOM MESSAGE")  # doctest: +SKIP_WINDOWS
         SignalError: CUSTOM MESSAGE
         >>> sig_print_exception(0)
         SystemError: unknown signal number 0
@@ -197,7 +199,7 @@ def sig_print_exception(sig, msg=None):
 
         >>> sig_print_exception(signal.SIGINT, "ignored")
         KeyboardInterrupt
-        >>> sig_print_exception(signal.SIGALRM, "ignored")
+        >>> sig_print_exception(signal.SIGALRM, "ignored")  # doctest: +SKIP_WINDOWS
         AlarmInterrupt
 
     """

--- a/src/cysignals/struct_signals.h
+++ b/src/cysignals/struct_signals.h
@@ -74,6 +74,9 @@ typedef struct
 #if ENABLE_DEBUG_CYSIGNALS
     int debug_level;
 #endif
+#if defined(__MINGW32__) || defined(_WIN32)
+    volatile sig_atomic_t sig_mapped_to_FPE;
+#endif
 } cysigs_t;
 
 #ifdef __cplusplus

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -172,8 +172,8 @@ def on_stack():
 
     EXAMPLES::
 
-        >>> from cysignals.tests import on_stack
-        >>> on_stack()
+        >>> from cysignals.tests import on_stack     # doctest: +SKIP_WINDOWS
+        >>> on_stack()                               # doctest: +SKIP_WINDOWS
         False
 
     """
@@ -360,7 +360,7 @@ def test_sig_retry_and_signal(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_sig_retry_and_signal()
+        >>> test_sig_retry_and_signal()  # doctest: +SKIP_WINDOWS
         KeyboardInterrupt()
 
     """
@@ -535,7 +535,7 @@ def test_signal_bus(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_signal_bus()
+        >>> test_signal_bus()  # doctest: +SKIP_WINDOWS
         Traceback (most recent call last):
         ...
         SignalError: Bus error
@@ -554,7 +554,7 @@ def test_signal_quit(long delay=DEFAULT_DELAY):
     ``sig_on()``.  This should cause Python to exit::
 
         >>> from cysignals.tests import subpython_err
-        >>> subpython_err('from cysignals.tests import *; test_signal_quit()')
+        >>> subpython_err('from cysignals.tests import *; test_signal_quit()')  # doctest: +SKIP_WINDOWS
         ---------------------------------------------------------------------...
 
     """
@@ -580,7 +580,7 @@ def test_dereference_null_pointer():
         Traceback (most recent call last):
         ...
         SignalError: ...
-        >>> on_stack()
+        >>> on_stack()  # doctest: +SKIP_WINDOWS
         False
 
     """
@@ -639,7 +639,16 @@ def unguarded_abort():
     We run Python in a subprocess and make it call abort()::
 
         >>> from cysignals.tests import subpython_err
-        >>> subpython_err('from cysignals.tests import *; unguarded_abort()')
+        >>> subpython_err('from cysignals.tests import *; unguarded_abort()')  # doctest: +SKIP_WINDOWS
+        ---------------------------------------------------------------------...
+        Unhandled SIGABRT: An abort() occurred.
+        This probably occurred because a *compiled* module has a bug
+        in it and is not properly wrapped with sig_on(), sig_off().
+        Python will now terminate.
+        ------------------------------------------------------------------------
+        >>> subpython_err('from cysignals.tests import *; unguarded_abort()')  # doctest: +SKIP_POSIX
+        <BLANKLINE>
+        ...
         ---------------------------------------------------------------------...
         Unhandled SIGABRT: An abort() occurred.
         This probably occurred because a *compiled* module has a bug
@@ -657,7 +666,7 @@ def test_stack_overflow():
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_stack_overflow()
+        >>> test_stack_overflow()  # doctest: +SKIP_WINDOWS
         Traceback (most recent call last):
         ...
         SignalError: Segmentation fault
@@ -674,7 +683,7 @@ def unguarded_stack_overflow():
     We run Python in a subprocess and overflow the stack::
 
         >>> from cysignals.tests import subpython_err
-        >>> subpython_err('from cysignals.tests import *; unguarded_stack_overflow()')
+        >>> subpython_err('from cysignals.tests import *; unguarded_stack_overflow()')  # doctest: +SKIP_WINDOWS
         ---------------------------------------------------------------------...
         Unhandled SIGSEGV: A segmentation fault occurred.
         This probably occurred because a *compiled* module has a bug
@@ -694,7 +703,7 @@ def test_bad_str(long delay=DEFAULT_DELAY):
     We run Python in a subprocess and induce an error during the signal handler::
 
         >>> from cysignals.tests import subpython_err
-        >>> subpython_err('from cysignals.tests import *; test_bad_str()')
+        >>> subpython_err('from cysignals.tests import *; test_bad_str()')  # doctest: +SKIP_WINDOWS
         ---------------------------------------------------------------------...
         An error occurred during signal handling.
         This probably occurred because a *compiled* module has a bug
@@ -754,7 +763,7 @@ def test_interrupt_bomb(long n=100, long p=10):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_interrupt_bomb()  # doctest: +SKIP_CYGWIN
+        >>> test_interrupt_bomb()  # doctest: +SKIP_WINDOWS +SKIP_CYGWIN
         Received ... interrupts
 
     """
@@ -866,8 +875,8 @@ def print_sig_occurred():
     and calling ``sys.exc_clear()`` clears it::
 
         >>> import sys
-        >>> from cysignals.alarm import alarm
-        >>> if hasattr(sys, "exc_clear"):
+        >>> from cysignals.alarm import alarm   # doctest: +SKIP_WINDOWS
+        >>> if hasattr(sys, "exc_clear"):       # doctest: +SKIP_WINDOWS
         ...     # Python 2
         ...     def testfunc():
         ...         try:
@@ -889,7 +898,7 @@ def print_sig_occurred():
         ...         except KeyboardInterrupt:
         ...             print_sig_occurred()
         ...         print_sig_occurred()
-        >>> testfunc()
+        >>> testfunc()  # doctest: +SKIP_WINDOWS
         AlarmInterrupt
         No current exception
 
@@ -984,7 +993,7 @@ def test_sig_block(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_sig_block()
+        >>> test_sig_block()  # doctest: +SKIP_WINDOWS
         42
 
     """
@@ -1010,7 +1019,7 @@ def test_sig_block_nested(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_sig_block()
+        >>> test_sig_block()  # doctest: +SKIP_WINDOWS
         42
 
     """
@@ -1133,7 +1142,7 @@ def test_sighup(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_sighup()
+        >>> test_sighup()  # doctest: +SKIP_WINDOWS
         SystemExit()
 
     """
@@ -1151,7 +1160,7 @@ def test_sighup_and_sigint(long delay=DEFAULT_DELAY):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_sighup_and_sigint()
+        >>> test_sighup_and_sigint()  # doctest: +SKIP_WINDOWS
         SystemExit()
 
     """
@@ -1175,20 +1184,20 @@ def test_graceful_exit():
 
         >>> from sys import executable
         >>> from subprocess import *
-        >>> A = Popen([executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        >>> _ = A.stdin.write(b'from cysignals.tests import test_graceful_exit\n')
-        >>> _ = A.stdin.write(b'test_graceful_exit()\n')
-        >>> A.stdin.close()
+        >>> A = Popen([executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)  # doctest: +SKIP_WINDOWS
+        >>> _ = A.stdin.write(b'from cysignals.tests import test_graceful_exit\n')  # doctest: +SKIP_WINDOWS
+        >>> _ = A.stdin.write(b'test_graceful_exit()\n')  # doctest: +SKIP_WINDOWS
+        >>> A.stdin.close()  # doctest: +SKIP_WINDOWS
 
     Now read from the child until we read ``"GO"``.  This ensures that
     the child process has properly started before we kill it::
 
-        >>> while b'GO' not in A.stdout.readline(): pass
+        >>> while b'GO' not in A.stdout.readline(): pass  # doctest: +SKIP_WINDOWS
         >>> import os, signal, sys
-        >>> os.kill(A.pid, signal.SIGHUP)
-        >>> _ = sys.stdout.write(A.stdout.read().decode("utf-8"))
+        >>> os.kill(A.pid, signal.SIGHUP)  # doctest: +SKIP_WINDOWS
+        >>> _ = sys.stdout.write(A.stdout.read().decode("utf-8"))  # doctest: +SKIP_WINDOWS
         Goodbye!
-        >>> A.wait()
+        >>> A.wait()  # doctest: +SKIP_WINDOWS
         0
 
     """

--- a/winutil/patchdistutils.py
+++ b/winutil/patchdistutils.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+"""
+This script 'monkey patch' distutils on windows platform.
+With python 32 bits distutils is patched to use mingw32 compiler
+With python 64 bits distutils is patched to use mingw64 compiler
+
+This script has been tested with the following version :
+python2.7.14, python2.7.14-64bits, python3.4.4, python3.4.4-64bits
+"""
+__author__ = "Vincent Klein"
+
+import sys
+from distutils.cygwinccompiler import CygwinCCompiler, is_cygwingcc
+
+
+# the same as cygwin plus some additional parameters
+class Mingw64CCompiler(CygwinCCompiler):
+
+    compiler_type = 'mingw64'
+
+    def __init__(self,
+                  verbose=0,
+                  dry_run=0,
+                  force=0):
+
+        CygwinCCompiler.__init__(self, verbose, dry_run, force)
+
+        # ld_version >= "2.13" support -shared so use it instead of
+        # -mdll -static
+        if self.ld_version >= "2.13":
+            shared_option = "-shared"
+        else:
+            shared_option = "-mdll -static"
+
+        # A real mingw32 doesn't need to specify a different entry point,
+        # but cygwin 2.91.57 in no-cygwin-mode needs it.
+        if self.gcc_version <= "2.91.57":
+            entry_point = '--entry _DllMain@12'
+        else:
+            entry_point = ''
+
+        if self.gcc_version < '4' or is_cygwingcc():
+            no_cygwin = ' -mno-cygwin'
+        else:
+            no_cygwin = ''
+
+        self.linker_dll = 'x86_64-w64-mingw32-gcc'
+
+        self.set_executables(compiler='x86_64-w64-mingw32-gcc%s -O -Wall' % no_cygwin,
+                             compiler_so='x86_64-w64-mingw32-gcc%s -mdll -O -Wall -D MS_WIN64' % no_cygwin,
+                             compiler_cxx='x86_64-w64-mingw32-g++%s -O -Wall' % no_cygwin,
+                             linker_exe='x86_64-w64-mingw32-gcc%s' % no_cygwin,
+                             linker_so='%s%s %s %s'
+                                    % (self.linker_dll, no_cygwin,
+                                       shared_option, entry_point))
+        # Maybe we should also append -mthreads, but then the finished
+        # dlls need another dll (mingwm10.dll see Mingw32 docs)
+        # (-mthreads: Support thread-safe exception handling on `Mingw32')
+
+        # no additional libraries needed
+        self.dll_libraries=[]
+
+        # Include the appropriate MSVC runtime library if Python was built
+        # with MSVC 7.0 or later.
+        #self.dll_libraries = get_msvcr()
+
+    # __init__ ()
+
+
+def get_msvcr():
+    """Include the appropriate MSVC runtime library if Python was built
+    with MSVC 7.0 or later.
+    """
+    msc_pos = sys.version.find('MSC v.')
+    if msc_pos != -1:
+        msc_ver = sys.version[msc_pos+6:msc_pos+10]
+        if msc_ver == '1300':
+            # MSVC 7.0
+            return ['msvcr70']
+        elif msc_ver == '1310':
+            # MSVC 7.1
+            return ['msvcr71']
+        elif msc_ver == '1400':
+            # VS2005 / MSVC 8.0
+            return ['msvcr80']
+        elif msc_ver == '1500':
+            # VS2008 / MSVC 9.0
+            return ['msvcr90']
+        elif msc_ver == '1600':
+            # VS2010 / MSVC 10.0
+            return ['msvcr100']
+        elif msc_ver == '1700':
+            # Visual Studio 2012 / Visual C++ 11.0
+            return ['msvcr110']
+        elif msc_ver == '1800':
+            # Visual Studio 2013 / Visual C++ 12.0
+            return ['msvcr120']
+        elif msc_ver == '1900':
+            # Visual Studio 2015 / Visual C++ 14.0
+            # "msvcr140.dll no longer exists" http://blogs.msdn.com/b/vcblog/archive/2014/06/03/visual-studio-14-ctp.aspx
+            return []
+        else:
+            raise ValueError("Unknown MS Compiler version %s " % msc_ver)
+
+
+def runtime_patch():
+    """
+    Apply the monkey patch
+    """
+    import struct
+    import distutils.cygwinccompiler as cygwinccompiler
+    import distutils.ccompiler as ccompiler
+
+    # compiler type for python 32bits
+    compiler = 'mingw32'
+    bit_version = struct.calcsize("P") * 8
+
+    if bit_version == 64:  # Python 64 bits
+        from distutils.ccompiler import compiler_class
+
+        cygwinccompiler.Mingw64CCompiler = Mingw64CCompiler
+        compiler_class['mingw64'] = ('cygwinccompiler', 'Mingw64CCompiler', "Mingw64 port of GNU C Compiler for Win64")
+
+        compiler = 'mingw64'
+
+    # get_msvcr() function should be patched for python version >= 3.5
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+        cygwinccompiler.get_msvcr = get_msvcr
+
+    # change default compiler for nt
+    ccompiler._default_compilers = (('nt', compiler),)


### PR DESCRIPTION
This PR is a proposal for issue #63. For feedback and advices.

The core of this PR is based on [cypari](https://bitbucket.org/t3m/cypari) fork of cysignals.

Continuous integration is working in four version python versions Python27, Python27-64bits, Python34 and  Python34-64bits ([build #186](https://ci.appveyor.com/project/vinklein/cysignals) for example). 

Some notes / remaining questions :
- I don't have managed yet to have working with python35 and python36.
- test_helper.c : signal_pid_after_delay use fork. There is no real equivalent to "fork" in windows. I have not find what the best way to manage this for windows.
- alarm.pyx: Not translated because SIGALRM doesn't exist on Windows.
- [Error](https://ci.appveyor.com/project/vinklein/cysignals/build/job/smlp68ikx94npxms.) with python 35 
- macro.h : I don't clearly understand the role of `win32ctrlc`
- tests.pyx `CYSIGNALS_CRASH_QUIET` doesn't work yet on windows. **Fixed**