### PR TITLE
Better handling on Cygwin for exceptions that occur during exception handling on an alt stack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,14 @@ macros = [
     ("CYTHON_CLINE_IN_TRACEBACK", 0),
 ]
 
+depends = glob(opj("src", "cysignals", "*.h"))
+
 if sys.platform == 'cygwin':
     # On Cygwin FD_SETSIZE defaults to a rather low 64; we set it higher
     # for use with PSelecter
     # See https://github.com/sagemath/cysignals/pull/57
     macros.append(('FD_SETSIZE', 512))
+    depends.append(opj("src", "cysignals", "implementation_cygwin.c"))
 
 # Disable sanity checking in GNU libc. This is required because of
 # false positives in the longjmp() check.
@@ -44,7 +47,7 @@ undef_macros = ["_FORTIFY_SOURCE"]
 
 kwds = dict(include_dirs=[opj("src"),
                           opj("src", "cysignals")],
-            depends=glob(opj("src", "cysignals", "*.h")),
+            depends=depends,
             define_macros=macros,
             undef_macros=undef_macros)
 

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -133,6 +133,7 @@ static inline void sig_reset_defaults(void) {
  * whether the exception occurred inside our signal handler */
 static inline void sigdie_for_sig(int sig, int inside)
 {
+    sig_reset_defaults();
     if (inside) sigdie(sig, "An error occurred during signal handling.");
 
     /* Quit Python with an appropriate message. */
@@ -249,7 +250,6 @@ static void cysigs_signal_handler(int sig)
 
         /* Reset all signals to their default behaviour and unblock
          * them in case something goes wrong as of now. */
-        sig_reset_defaults();
         sigdie_for_sig(sig, inside);
     }
 }

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -546,8 +546,11 @@ static void sigdie(int sig, const char* s)
      * the user is probably using other debugging tools and we don't
      * want to interfere with that. */
 #else
-#ifndef __APPLE__
+#if !(defined(__APPLE__) || defined(__CYGWIN__))
     /* See http://trac.sagemath.org/13889 for how Apple screwed this up */
+    /* On Cygwin this has never quite worked, and in particular when run
+       from the altstack handler it just results in fork errors, so disable
+       this feature for now */
     if (getenv("CYSIGNALS_CRASH_NDEBUG") == NULL)
         print_enhanced_backtrace();
 #endif

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -162,6 +162,12 @@ static inline void sigdie_for_sig(int sig, int inside)
 }
 
 
+/* Additional platform-specific implementation code */
+#if defined(__CYGWIN__) && defined(__x86_64__)
+#include "implementation_cygwin.h"
+#endif
+
+
 /* Handler for SIGHUP, SIGINT, SIGALRM
  *
  * Inside sig_on() (i.e. when cysigs.sig_on_count is positive), this
@@ -406,6 +412,7 @@ static void setup_alt_stack(void)
     ss.ss_size = sizeof(alt_stack);
     ss.ss_flags = 0;
     if (sigaltstack(&ss, NULL) == -1) {perror("sigaltstack"); exit(1);}
+    PLATFORM_SETUP_ALT_STACK;
 }
 
 

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -93,7 +93,6 @@ static void print_backtrace(void);
 /* Implemented in signals.pyx */
 static int sig_raise_exception(int sig, const char* msg);
 
-
 /* Do whatever is needed to reset the CPU to a sane state after
  * handling a signals.  In particular on x86 CPUs, we need to clear
  * the FPU (this is needed after MMX instructions have been used or
@@ -163,8 +162,8 @@ static inline void sigdie_for_sig(int sig, int inside)
 
 
 /* Additional platform-specific implementation code */
-#if defined(__CYGWIN__) && defined(__x86_64__)
-#include "implementation_cygwin.h"
+#if defined(__CYGWIN__)
+#include "implementation_cygwin.c"
 #endif
 
 
@@ -412,7 +411,9 @@ static void setup_alt_stack(void)
     ss.ss_size = sizeof(alt_stack);
     ss.ss_flags = 0;
     if (sigaltstack(&ss, NULL) == -1) {perror("sigaltstack"); exit(1);}
-    PLATFORM_SETUP_ALT_STACK;
+#if defined(__CYGWIN__) && defined(__x86_64__)
+    cygwin_setup_alt_stack();
+#endif
 }
 
 

--- a/src/cysignals/implementation_cygwin.c
+++ b/src/cysignals/implementation_cygwin.c
@@ -56,6 +56,9 @@ LONG WINAPI win32_altstack_handler(EXCEPTION_POINTERS *exc)
     return ExceptionContinueExecution;
 }
 
-#undef PLATFORM_SETUP_ALT_STACK
-#define PLATFORM_SETUP_ALT_STACK AddVectoredContinueHandler(0, win32_altstack_handler)
+
+static void cygwin_setup_alt_stack() {
+    AddVectoredContinueHandler(0, win32_altstack_handler);
+}
+
 #endif  /* CYGWIN && __x86_64__ */

--- a/src/cysignals/implementation_cygwin.c
+++ b/src/cysignals/implementation_cygwin.c
@@ -51,7 +51,6 @@ LONG WINAPI win32_altstack_handler(EXCEPTION_POINTERS *exc)
             break;
     }
 
-    sig_reset_defaults();
     sigdie_for_sig(sig, 1);
     return ExceptionContinueExecution;
 }

--- a/src/cysignals/implementation_cygwin.h
+++ b/src/cysignals/implementation_cygwin.h
@@ -1,0 +1,61 @@
+/* Cygwin-specific implementation details */
+
+#if defined(__CYGWIN__) && defined(__x86_64__)
+#include <w32api/errhandlingapi.h>
+LONG WINAPI win32_altstack_handler(EXCEPTION_POINTERS *exc)
+{
+    int sig = 0;
+    /* Logic cribbed from Cygwin for mapping common Windows exception
+     * codes to the relevant signal numbers:
+     * https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=winsup/cygwin/exceptions.cc;h=77eff05707f95f7277974fadbccf0e74223d8d1c;hb=HEAD#l650
+     * Unfortunately there is no external API by which to access this
+     * mapping (a la cygwin_internal(CW_GET_ERRNO_FROM_WINERROR, ...)) */
+    switch (exc->ExceptionRecord->ExceptionCode) {
+        case STATUS_FLOAT_DENORMAL_OPERAND:
+        case STATUS_FLOAT_DIVIDE_BY_ZERO:
+        case STATUS_FLOAT_INVALID_OPERATION:
+        case STATUS_FLOAT_STACK_CHECK:
+        case STATUS_FLOAT_INEXACT_RESULT:
+        case STATUS_FLOAT_OVERFLOW:
+        case STATUS_FLOAT_UNDERFLOW:
+        case STATUS_INTEGER_DIVIDE_BY_ZERO:
+        case STATUS_INTEGER_OVERFLOW:
+            sig = SIGFPE;
+            break;
+        case STATUS_ILLEGAL_INSTRUCTION:
+        case STATUS_PRIVILEGED_INSTRUCTION:
+        case STATUS_NONCONTINUABLE_EXCEPTION:
+            sig = SIGILL;
+            break;
+        case STATUS_TIMEOUT:
+            sig = SIGALRM;
+            break;
+        case STATUS_GUARD_PAGE_VIOLATION:
+        case STATUS_DATATYPE_MISALIGNMENT:
+            sig = SIGBUS;
+            break;
+        case STATUS_ACCESS_VIOLATION:
+            /* In the case of this last resort exception handling we can
+             * probably safely assume this should be a SIGSEGV;
+             * other access violations would have already been handled by
+             * Cygwin before we wound up on the alternate stack */
+        case STATUS_STACK_OVERFLOW:
+        case STATUS_ARRAY_BOUNDS_EXCEEDED:
+        case STATUS_IN_PAGE_ERROR:
+        case STATUS_NO_MEMORY:
+        case STATUS_INVALID_DISPOSITION:
+            sig = SIGSEGV;
+            break;
+        case STATUS_CONTROL_C_EXIT:
+            sig = SIGINT;
+            break;
+    }
+
+    sig_reset_defaults();
+    sigdie_for_sig(sig, 1);
+    return ExceptionContinueExecution;
+}
+
+#undef PLATFORM_SETUP_ALT_STACK
+#define PLATFORM_SETUP_ALT_STACK AddVectoredContinueHandler(0, win32_altstack_handler)
+#endif  /* CYGWIN && __x86_64__ */


### PR DESCRIPTION
This is a rough idea for how to fix #77.  Actually it seems to work pretty reliably but I admit I haven't fully worked out the implications for continuing to do anything with Cygwin in this environment.  It's probably pretty unsafe, but this is still better than the current situation (where the OS just quietly terminates the process, and never even sets the exit code in a way that Cygwin can keep track of).