### PR TITLE
Cygwin builds on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,9 @@ environment:
       MAKE: make
 
 before_build:
+  - echo "Building Cysignals for %OS%"
+  - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
+  - echo %PATH%
   - ps: >-
       if ( "$Env:OS" -ieq "Cygwin" ) {
           if ( $Env:PYTHON[0] -ieq "2") {
@@ -24,15 +27,14 @@ before_build:
           } else {
               $python = "python" + $Env:PYTHON[0]
           }
+          Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "C:\get-pip.py"
           & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core
+          & $python "C:\get-pip.py"
       }
-  - echo "Building Cysignals for %OS%"
-  - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
-  - echo %PATH%
   - cd C:\projects\cysignals
-  - pip install -r requirements.txt
-  - python --version
-  - python -m cython --version
+  - python%PYTHON_VERSION% -m pip install -r requirements.txt
+  - python%PYTHON_VERSION% --version
+  - python%PYTHON_VERSION% -m cython --version
 
 build_script:
   - '%MAKE% -j4 install'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,41 @@
+version: 1.0.{build}
+
+build: off
+
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+    - os: Cygwin
+      CYG_ROOT: "C:\\cygwin64"
+      PYTHON: "C:\\cygwin64\\bin"
+      PYTHON_VERSION: "2.7"
+      ARCH: x86_64
+      MAKE: make
+
+before_build:
+  - ps: >-
+      if ( "$Env:OS" -ieq "Cygwin" ) {
+          if ( $Env:PYTHON[0] -ieq "2") {
+              $python = "python"
+          } else {
+              $python = "python" + $Env:PYTHON[0]
+          }
+          & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core
+      }
+  - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
+  - echo %PATH%
+  - cd C:\projects\cysignals
+  - pip install -r requirements.txt
+  - python --version
+  - python -m cython --version
+
+build_script:
+  - '%MAKE% -j4 install'
+
+test_script:
+  - '%MAKE% -j4 check-all distcheck'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,10 +22,10 @@ before_build:
   - echo %PATH%
   - ps: >-
       if ( "$Env:OS" -ieq "Cygwin" ) {
-          if ( $Env:PYTHON[0] -ieq "2") {
+          if ( $Env:PYTHON_VERSION[0] -ieq "2") {
               $python = "python"
           } else {
-              $python = "python" + $Env:PYTHON[0]
+              $python = "python" + $Env:PYTHON_VERSION[0]
           }
           Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "C:\get-pip.py"
           & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,10 @@ before_build:
           } else {
               $python = "python" + $Env:PYTHON_VERSION[0]
           }
+          $python_exe = "python" + $Env:PYTHON_VERSION
           Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "C:\get-pip.py"
           & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core
-          & $python "C:\get-pip.py"
+          & $python_exe "C:\get-pip.py"
       }
   - cd C:\projects\cysignals
   - python%PYTHON_VERSION% -m pip install -r requirements.txt

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ version: 1.0.{build}
 build: off
 
 environment:
-
   matrix:
 
     # For Python versions available on Appveyor, see
@@ -27,6 +26,7 @@ before_build:
           }
           & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core
       }
+  - echo "Building Cysignals for %OS%"
   - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
   - echo %PATH%
   - cd C:\projects\cysignals

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ before_build:
               -OutFile "C:\get-pip.py"
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
-              -ArgumentList "-q -P $python $python-devel gcc-core"
+              -ArgumentList "-q -P $python,$python-devel,gcc-core"
           & $python_exe "C:\get-pip.py"
       }
   - cd C:\projects\cysignals

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,11 @@ before_build:
               $python = "python" + $Env:PYTHON_VERSION[0]
           }
           $python_exe = "python" + $Env:PYTHON_VERSION
-          Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" -OutFile "C:\get-pip.py"
-          & $Env:CYG_ROOT\setup-$Env:ARCH.exe -q -P $python $python-devel gcc-core
+          Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" `
+              -OutFile "C:\get-pip.py"
+          Start-Process -NoNewWindow -Wait `
+              -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
+              -ArgumentList "-q -P $python $python-devel gcc-core"
           & $python_exe "C:\get-pip.py"
       }
   - cd C:\projects\cysignals

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ cysignals: interrupt and signal handling for Cython
 .. image:: https://travis-ci.org/sagemath/cysignals.svg?branch=master
     :target: https://travis-ci.org/sagemath/cysignals
 
+.. image:: https://ci.appveyor.com/api/projects/status/vagqk56cj3ndycp4?svg=true
+    :target: https://ci.appveyor.com/project/sagemath/cysignals
+
 .. image:: https://readthedocs.org/projects/cysignals/badge/?version=latest
     :target: http://cysignals.readthedocs.org
 

--- a/rundoctests.py
+++ b/rundoctests.py
@@ -9,11 +9,50 @@
 import os
 import sys
 import doctest
-import resource
+from doctest import DocTestParser, OPTIONFLAGS_BY_NAME
+from multiprocessing import Process
+if os.name != 'nt':
+    import resource
 
 flags = doctest.ELLIPSIS
+timeout = 600
 
-filenames = sys.argv[1:]
+filenames = list(sys.argv[1:])
+if os.name == 'nt':
+    notinwindows = ['src/cysignals/pysignals.pyx', 'src/cysignals/alarm.pyx', 'src/cysignals/pselect.pyx']
+
+    for f in list(filenames):
+        if f in notinwindows:
+            filenames.remove(f)
+
+# Add an option to flag doctest what should not be run on windows.
+doctest.register_optionflag("SKIP_WINDOWS")
+doctest.register_optionflag("SKIP_POSIX")
+flag_skip_windows = OPTIONFLAGS_BY_NAME["SKIP_WINDOWS"]
+flag_skip_posix = OPTIONFLAGS_BY_NAME["SKIP_POSIX"]
+
+
+class SkipByOsDocTestParser(DocTestParser):
+
+    def _find_options(self, source, name, lineno):
+        options = DocTestParser._find_options(self, source, name, lineno)
+
+        if flag_skip_windows in options.keys() and os.name == 'nt':
+            # Replace SKIP_WINDOWS with SKIP flag if we are on windows.
+            options[OPTIONFLAGS_BY_NAME["SKIP"]] = options[flag_skip_windows]
+            del options[flag_skip_windows]
+
+        if flag_skip_posix in options.keys() and os.name != 'nt':
+            # Replace SKIP_POSIX with SKIP flag if we are not on windows.
+            options[OPTIONFLAGS_BY_NAME["SKIP"]] = options[flag_skip_posix]
+            del options[flag_skip_posix]
+
+        return options
+
+
+parser = SkipByOsDocTestParser()
+
+
 print("Doctesting {} files.".format(len(filenames)))
 
 # For doctests, we want exceptions to look the same,
@@ -24,47 +63,55 @@ from cysignals.signals import AlarmInterrupt, SignalError
 for typ in [AlarmInterrupt, SignalError]:
     typ.__module__ = "__main__"
 
+if os.name != 'nt':
+    # Limit stack size to avoid errors in stack overflow doctest
+    stacksize = 1 << 20
+    resource.setrlimit(resource.RLIMIT_STACK, (stacksize, stacksize))
 
-# Limit stack size to avoid errors in stack overflow doctest
-stacksize = 1 << 20
-resource.setrlimit(resource.RLIMIT_STACK, (stacksize, stacksize))
+    # Disable core dumps
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
 
-# Disable core dumps
-resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+def testfile(file):
+    # Child process
+    try:
+        if sys.platform == 'darwin':
+            from cysignals.signals import _setup_alt_stack
+            _setup_alt_stack()
+        failures, _ = doctest.testfile(file, module_relative=False, optionflags=flags, parser=parser)
+        if not failures:
+            os._exit(0)
+    finally:
+        os._exit(23)
 
+if __name__ == "__main__": # Mandatory for windows cases.
+    success = True
+    for f in filenames:
+        print(f)
+        sys.stdout.flush()
 
-success = True
-for f in filenames:
-    print(f)
-    sys.stdout.flush()
+        # Test every file in a separate process (like in SageMath) to avoid
+        # side effects from doctests.
+        p = Process(target=testfile, args=(f,))
+        p.start()
+        p.join(timeout)
 
-    # Test every file in a separate process (like in SageMath) to avoid
-    # side effects from doctests.
-    pid = os.fork()
-    if not pid:
-        # Child process
-        try:
-            if sys.platform == 'darwin':
-                from cysignals.signals import _setup_alt_stack
-                _setup_alt_stack()
-            failures, _ = doctest.testfile(f, module_relative=False, optionflags=flags)
-            if not failures:
-                os._exit(0)
-        finally:
-            os._exit(23)
+        status = p.exitcode
 
-    pid, status = os.waitpid(pid, 0)
-    if status != 0:
-        success = False
-        if os.WIFEXITED(status):
-            st = os.WEXITSTATUS(status)
-            if st != 23:
-                print("bad exit: {}".format(st))
-        elif os.WIFSIGNALED(status):
-            sig = os.WTERMSIG(status)
-            print("killed by signal: {}".format(sig))
-        else:
-            print("unknown status: {}".format(status))
+        if p.is_alive():
+            p.terminate()
+            print("Doctest {} terminated. Timeout limit exceeded (>{}s)".format(f, timeout))
+            success = False
+        elif status != 0:
+            success = False
+            if os.name != 'nt':
+                if os.WIFEXITED(status):
+                    st = os.WEXITSTATUS(status)
+                    if st != 23:
+                        print("bad exit: {}".format(st))
+                elif os.WIFSIGNALED(status):
+                    sig = os.WTERMSIG(status)
+                    print("killed by signal: {}".format(sig))
+                else:
+                    print("unknown status: {}".format(status))
 
-
-sys.exit(0 if success else 1)
+    sys.exit(0 if success else 1)

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -745,7 +745,7 @@ def test_interrupt_bomb(long n=100, long p=10):
     TESTS::
 
         >>> from cysignals.tests import *
-        >>> test_interrupt_bomb()
+        >>> test_interrupt_bomb()  # doctest: +SKIP_CYGWIN
         Received ... interrupts
 
     """


### PR DESCRIPTION
Implements #92 in a manner intended to be compatible with #76.  Depends on #94.

It would probably be best to implement #76 first and then merge this into its `.appveyor.yml`.  But we could also do it the other way around depending on how things go with #76.

See https://ci.appveyor.com/project/embray/cysignals for sample builds.