### PR TITLE
Run autoreconf instead of autoconf & autoheader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,7 @@ distcheck: dist
 #####################
 
 configure: configure.ac
-	autoconf
-	autoheader
+	autoreconf -if
 	@rm -f src/config.h.in~
 
 .PHONY: all build doc install dist doc clean clean-build clean-doc \


### PR DESCRIPTION
this is an attempt to upstream bits of Debian's patches, namely @jgmbenoit's `upstream-autotoolization-harden-generic.patch`.