### PR TITLE
Cygwin builds on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: "build #{build}"
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,48 @@
+version: 1.0.{build}
+
+build: off
+
+environment:
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+    - os: Cygwin
+      CYG_ROOT: "C:\\cygwin64"
+      PYTHON: "C:\\cygwin64\\bin"
+      PYTHON_VERSION: "2.7"
+      ARCH: x86_64
+      MAKE: make
+
+before_build:
+  - echo "Building Cysignals for %OS%"
+  - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
+  - echo %PATH%
+  - ps: >-
+      if ( "$Env:OS" -ieq "Cygwin" ) {
+          if ( $Env:PYTHON_VERSION[0] -ieq "2") {
+              $python = "python"
+          } else {
+              $python = "python" + $Env:PYTHON_VERSION[0]
+          }
+          $python_exe = "python" + $Env:PYTHON_VERSION
+          Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" `
+              -OutFile "C:\get-pip.py"
+          Start-Process -NoNewWindow -Wait `
+              -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
+              -ArgumentList "-q -P $python,$python-devel,gcc-core,gcc-g++"
+          & $python_exe "C:\get-pip.py"
+      }
+  - cd C:\projects\cysignals
+  - python%PYTHON_VERSION% -m pip install -r requirements.txt
+  - python%PYTHON_VERSION% --version
+  - python%PYTHON_VERSION% -m cython --version
+
+build_script:
+  - '%MAKE% -j4 install'
+
+test_script:
+  - '%MAKE% -j4 check-all'
+  - '%MAKE% -j4 distcheck'

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ cysignals: interrupt and signal handling for Cython
 .. image:: https://travis-ci.org/sagemath/cysignals.svg?branch=master
     :target: https://travis-ci.org/sagemath/cysignals
 
+.. image:: https://ci.appveyor.com/api/projects/status/vagqk56cj3ndycp4?svg=true
+    :target: https://ci.appveyor.com/project/sagemath/cysignals
+
 .. image:: https://readthedocs.org/projects/cysignals/badge/?version=latest
     :target: http://cysignals.readthedocs.org
 


### PR DESCRIPTION
CC @embray 

Unfortunately failing with
```
gcc -fno-strict-aliasing -ggdb -O2 -pipe -Wimplicit-function-declaration -fdebug-prefix-map=/usr/src/ports/python2/python2-2.7.14-1.x86_64/build=/usr/src/debug/python2-2.7.14-1 -fdebug-prefix-map=/usr/src/ports/python2/python2-2.7.14-1.x86_64/src/Python-2.7.14=/usr/src/debug/python2-2.7.14-1 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/cygdrive/c/projects/cysignals/tmp/site-packages/cysignals -I/usr/include/python2.7 -c cysignals_example.cpp -o build/temp.cygwin-2.10.0-x86_64-2.7/cysignals_example.o
gcc: error: spawn: No such file or directory
```

This may be relevant: https://stackoverflow.com/questions/16621529/gcc-fails-with-spawn-no-such-file-or-directory