### PR TITLE
get-pip.py now writes a warning if run with python2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ before_build:
   - echo %PATH%
   - ps: >-
       if ( "$Env:OS" -ieq "Cygwin" ) {
-          $python = "python" + $Env:PYTHON_VERSION[0]
+          $python = "python" + $Env:PYTHON_VERSION[0] + $Env:PYTHON_VERSION[2]
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
               -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ before_build:
               -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"
       }
   - cd C:\projects\cysignals
-  - python%PYTHON_VERSION% --version
+  - python%PYTHON_VERSION% -c "import sys; print(sys.version); print(sys.platform); print(sys.path)"
   - python%PYTHON_VERSION% -m pip install -r requirements.txt
   - python%PYTHON_VERSION% -m cython --version
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,12 +22,7 @@ before_build:
   - echo %PATH%
   - ps: >-
       if ( "$Env:OS" -ieq "Cygwin" ) {
-          if ( $Env:PYTHON_VERSION[0] -ieq "2") {
-              $python = "python"
-          } else {
-              $python = "python" + $Env:PYTHON_VERSION[0]
-          }
-          $python_exe = "python" + $Env:PYTHON_VERSION
+          $python = "python" + $Env:PYTHON_VERSION[0]
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
               -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,8 @@ before_build:
               -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"
       }
   - cd C:\projects\cysignals
-  - python%PYTHON_VERSION% -m pip install -r requirements.txt
   - python%PYTHON_VERSION% --version
+  - python%PYTHON_VERSION% -m pip install -r requirements.txt
   - python%PYTHON_VERSION% -m cython --version
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,8 +33,8 @@ before_build:
   - python%PYTHON_VERSION% -m cython --version
 
 build_script:
-  - '%MAKE% -j4 install'
+  - '%MAKE% install'
 
 test_script:
-  - '%MAKE% -j4 check-all'
-  - '%MAKE% -j4 distcheck'
+  - '%MAKE% check-all'
+  - '%MAKE% distcheck'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ before_build:
           $python = "python" + $Env:PYTHON_VERSION[0] + $Env:PYTHON_VERSION[2]
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
-              -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"
+              -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++,libcrypt-devel"
       }
   - cd C:\projects\cysignals
   - python%PYTHON_VERSION% -c "import sys; print(sys.version); print(sys.platform); print(sys.path)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,12 +28,9 @@ before_build:
               $python = "python" + $Env:PYTHON_VERSION[0]
           }
           $python_exe = "python" + $Env:PYTHON_VERSION
-          Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" `
-              -OutFile "C:\get-pip.py"
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
-              -ArgumentList "-q -P $python,$python-devel,gcc-core,gcc-g++"
-          & $python_exe "C:\get-pip.py"
+              -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++"
       }
   - cd C:\projects\cysignals
   - python%PYTHON_VERSION% -m pip install -r requirements.txt


### PR DESCRIPTION
cygwin has python2-pip and python3-pip packages now so maybe it's best
to just use the system package

attempting to fix #105 