### PR TITLE
Partial workaround for use of win32_altstack_handler in inappropriate contexts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ fi
 
 AC_LANG(C)
 
-AC_CHECK_HEADERS([execinfo.h sys/prctl.h sys/time.h sys/wait.h windows.h])
+AC_CHECK_HEADERS([execinfo.h sys/mman.h sys/prctl.h sys/time.h sys/wait.h windows.h])
 AC_CHECK_FUNCS([fork kill sigprocmask sigaltstack backtrace])
 
 have_pari=no


### PR DESCRIPTION
See https://trac.sagemath.org/ticket/27214#comment:11

One thing I might also add is in the case of `STATUS_ACCESS_VIOLATION`, one thing I can do at the very least is query the Windows VMM for the state of the accessed memory region.  If it returns `MAP_RESERVE` there's a good chance we are hitting the still unhandled corner case I described in the comments, and can print an additional message with the hint about using `mprotect(...)`.  I'm not sure it really matters though.