### PR TITLE
Better support for threads

### DIFF
--- a/src/cysignals/struct_signals.h
+++ b/src/cysignals/struct_signals.h
@@ -72,6 +72,9 @@ typedef struct
      * interrupt-like signals are masked. */
     volatile atomic_int interrupt_received;
 
+    /* Signal raised by non-Python thread. */
+    volatile atomic_int thread_signal;
+
     /* Are we currently handling a signal inside cysigs_signal_handler()?
      * This is set to 1 on entry in cysigs_signal_handler (not in
      * cysigs_interrupt_handler) and 0 in _sig_on_postjmp.  This is


### PR DESCRIPTION
This pull request aims to improve thread-safety of cysignals. There are many aspects to it and this does not claim to fix all thread-related issues. In particular, we assume that there is only 1 thread any time that `sig_on()` is called. In particular, we don't support Python multithreading.