### PR TITLE
Change package_dir invocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ Changelog
 1.10.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+* Improved installation of cysignals with ``pip install -e``. [#130]
+
 * Fixed compilation of OpenMP modules that also use cysignals. [#128]
 
 * Fixed segmentation fault that could occur when ``sig_occurred()`` is

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
 
     ext_modules=extensions,
     packages=["cysignals"],
-    package_dir={"cysignals": opj("src", "cysignals")},
+    package_dir={"": "src"},
     package_data={"cysignals": ["*.pxd", "*.h"]},
     data_files=[(opj("share", "cysignals"), [opj("src", "scripts", "cysignals-CSI-helper.py")])],
     scripts=glob(opj("src", "scripts", "cysignals-CSI")),


### PR DESCRIPTION
While the way it's currently used is not *wrong* it's also a little
uncommon, and some other tools don't work properly in this case.
In particular, installing in develop mode / running `pip install -e .`
does not work properly.