### PR TITLE
define ATOMIC macros as 0 per default

### DIFF
--- a/src/cysignals/cysignals_config.h.in
+++ b/src/cysignals/cysignals_config.h.in
@@ -34,16 +34,16 @@
 /* Which implementation of atomic variables (if any) to use? */
 #ifndef __cplusplus
 
-#if defined(CYSIGNALS_C_ATOMIC_WITH_OPENMP) || !_OPENMP
+#if defined(CYSIGNALS_C_ATOMIC_WITH_OPENMP) || !defined(_OPENMP)
 #undef CYSIGNALS_C_ATOMIC
 #endif
 
 #else
 
-#if defined(CYSIGNALS_CXX_ATOMIC_WITH_OPENMP) || !_OPENMP
+#if defined(CYSIGNALS_CXX_ATOMIC_WITH_OPENMP) || !defined(_OPENMP)
 #undef CYSIGNALS_CXX_ATOMIC
 #endif
-#if defined(CYSIGNALS_STD_ATOMIC_WITH_OPENMP) || !_OPENMP
+#if defined(CYSIGNALS_STD_ATOMIC_WITH_OPENMP) || !defined(_OPENMP)
 #undef CYSIGNALS_STD_ATOMIC
 #endif
 

--- a/src/cysignals/cysignals_config.h.in
+++ b/src/cysignals/cysignals_config.h.in
@@ -27,17 +27,24 @@
 
 
 /* An implementation of atomic variables might not be allowed with OpenMP */
-#if _OPENMP
-#define CYSIGNALS_C_ATOMIC CYSIGNALS_C_ATOMIC_WITH_OPENMP
-#define CYSIGNALS_CXX_ATOMIC CYSIGNALS_CXX_ATOMIC_WITH_OPENMP
-#define CYSIGNALS_STD_ATOMIC CYSIGNALS_STD_ATOMIC_WITH_OPENMP
-#endif
-
+#undef CYSIGNALS_C_ATOMIC_WITH_OPENMP
+#undef CYSIGNALS_CXX_ATOMIC_WITH_OPENMP
+#undef CYSIGNALS_STD_ATOMIC_WITH_OPENMP
 
 /* Which implementation of atomic variables (if any) to use? */
 #ifndef __cplusplus
+
+#ifdef CYSIGNALS_C_ATOMIC_WITH_OPENMP || !_OPENMP
 #undef CYSIGNALS_C_ATOMIC
+#endif
+
 #else
+
+#ifdef CYSIGNALS_CXX_ATOMIC_WITH_OPENMP || !_OPENMP
 #undef CYSIGNALS_CXX_ATOMIC
+#endif
+#ifdef CYSIGNALS_STD_ATOMIC_WITH_OPENMP || !_OPENMP
 #undef CYSIGNALS_STD_ATOMIC
+#endif
+
 #endif

--- a/src/cysignals/cysignals_config.h.in
+++ b/src/cysignals/cysignals_config.h.in
@@ -34,16 +34,16 @@
 /* Which implementation of atomic variables (if any) to use? */
 #ifndef __cplusplus
 
-#ifdef CYSIGNALS_C_ATOMIC_WITH_OPENMP || !_OPENMP
+#if defined(CYSIGNALS_C_ATOMIC_WITH_OPENMP) || !_OPENMP
 #undef CYSIGNALS_C_ATOMIC
 #endif
 
 #else
 
-#ifdef CYSIGNALS_CXX_ATOMIC_WITH_OPENMP || !_OPENMP
+#if defined(CYSIGNALS_CXX_ATOMIC_WITH_OPENMP) || !_OPENMP
 #undef CYSIGNALS_CXX_ATOMIC
 #endif
-#ifdef CYSIGNALS_STD_ATOMIC_WITH_OPENMP || !_OPENMP
+#if defined(CYSIGNALS_STD_ATOMIC_WITH_OPENMP) || !_OPENMP
 #undef CYSIGNALS_STD_ATOMIC
 #endif
 


### PR DESCRIPTION
I made a mistake in #128.

The state of `CYSIGNALS_C_ATOMIC` and friends is `1` or undefined.

This has the unfortunate consequence that

  #define CYSIGNALS_C_ATOMIC CYSIGNALS_C_ATOMIC_WITH_OPENMP

will not define `CYSIGNALS_C_ATOMIC` just as `CYSIGNALS_C_ATOMIC_WITH_OPENMP`, but if the later is undefined this will just define `CYSIGNALS_C_ATOMIC` and then

    #if CYSIGNALS_C_ATOMIC

will unexpectedly evaluate to true.

Sorry about the mess.

(What is a greater mess yet is that in principle defining macros in configuration and then undefining them in a configured file seems to not work well. For me `src/cysignals/cysignals_config.h.in` looks way different then `src/cysignals/cysignals_config.h`.)