### PR TITLE
Run `twine check` on the source tarball during CI checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
     # The flake8 package on conda is quite broken on Python 2.7 and 3.4;
     # use pip to install it instead.  After support for these older versions
     # dropped we can can go back to the conda package.
-    - pip install flake8
+    - pip install flake8 twine
     - export LDFLAGS="-L$CONDA_PREFIX/lib"
     - export CFLAGS="-I$CONDA_PREFIX/include"
 
@@ -63,6 +63,7 @@ script:
     - make -j4 install
     - make -j4 check-all
     - make -j4 distcheck
+    - twine check dist/*
     - flake8 --max-line-length=88 --ignore=E265 src
     - python -c "from cysignals.signals import _pari_version; assert bool(_pari_version()) == ('$PARI' == 'yes')"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
     - osx
 
 env:
+  global:
+    - PYTHON_LATEST_SUPPORTED=3.7
   matrix:
     - PYTHON_VERSION=2.7 PARI=yes
     - PYTHON_VERSION=3.4 PARI=yes
@@ -50,7 +52,8 @@ install:
     # The flake8 package on conda is quite broken on Python 2.7 and 3.4;
     # use pip to install it instead.  After support for these older versions
     # dropped we can can go back to the conda package.
-    - pip install flake8 twine
+    - pip install flake8
+    - if [ "$PYTHON_VERSION" = "$PYTHON_LATEST_SUPPORTED" ]; then pip install twine; fi
     - export LDFLAGS="-L$CONDA_PREFIX/lib"
     - export CFLAGS="-I$CONDA_PREFIX/include"
 
@@ -63,7 +66,7 @@ script:
     - make -j4 install
     - make -j4 check-all
     - make -j4 distcheck
-    - twine check dist/*
+    - if [ "$PYTHON_VERSION" = "$PYTHON_LATEST_SUPPORTED" ]; then twine check dist/*; fi
     - flake8 --max-line-length=88 --ignore=E265 src
     - python -c "from cysignals.signals import _pari_version; assert bool(_pari_version()) == ('$PARI' == 'yes')"
 

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
     license="GNU Lesser General Public License, version 3 or later",
     description="Interrupt and signal handling for Cython",
     long_description=README,
+    long_description_content_type='text/x-rst',
     classifiers=classifiers,
     install_requires=["Cython>=0.28"],
     setup_requires=["Cython>=0.28"],


### PR DESCRIPTION
Add missing long_description_content_type keyword in setup.py.