### PR TITLE
Check for macros correctly

### DIFF
--- a/src/cysignals/cysetjmp.h
+++ b/src/cysignals/cysetjmp.h
@@ -26,7 +26,7 @@
 #include <setjmp.h>
 
 
-#if CYSIGNALS_ASM_CYSETJMP
+#ifdef CYSIGNALS_ASM_CYSETJMP
 #ifdef __x86_64__
 /*
  * x86_64 assembly implementation of cysetjmp(): we store the registers

--- a/src/cysignals/macros.h
+++ b/src/cysignals/macros.h
@@ -62,7 +62,7 @@ extern "C" {
  * sends a signal to the calling thread, while kill() typically sends
  * a signal to the main thread (although this is not guaranteed by the
  * POSIX standard) */
-#if HAVE_KILL
+#ifdef HAVE_KILL
 #define proc_raise(sig)  kill(getpid(), sig)
 #else
 /* On Windows, raise() actually signals the process */
@@ -115,7 +115,7 @@ extern "C" {
 static inline int _sig_on_prejmp(const char* message, const char* file, int line)
 {
     cysigs.s = message;
-#if ENABLE_DEBUG_CYSIGNALS
+#ifdef ENABLE_DEBUG_CYSIGNALS
     if (cysigs.debug_level >= 4)
     {
         fprintf(stderr, "sig_on (count = %i) at %s:%i\n",
@@ -179,7 +179,7 @@ static inline int _sig_on_postjmp(int jmpret)
  */
 static inline void _sig_off_(const char* file, int line)
 {
-#if ENABLE_DEBUG_CYSIGNALS
+#ifdef ENABLE_DEBUG_CYSIGNALS
     if (cysigs.debug_level >= 4)
     {
         fprintf(stderr, "sig_off (count = %i) at %s:%i\n",
@@ -254,7 +254,7 @@ static inline void sig_block(void)
 
 static inline void sig_unblock(void)
 {
-#if ENABLE_DEBUG_CYSIGNALS
+#ifdef ENABLE_DEBUG_CYSIGNALS
     if (cysigs.block_sigint < 1)
     {
         fprintf(stderr, "\n*** ERROR *** sig_unblock() with sig_on_count = %i, block_sigint = %i\n",
@@ -301,7 +301,7 @@ static inline void sig_error(void)
 
 static inline int _set_debug_level(int level)
 {
-#if ENABLE_DEBUG_CYSIGNALS
+#ifdef ENABLE_DEBUG_CYSIGNALS
     int old = cysigs.debug_level;
     cysigs.debug_level = level;
     return old;

--- a/src/cysignals/struct_signals.h
+++ b/src/cysignals/struct_signals.h
@@ -29,9 +29,9 @@
 
 
 /* Define a cy_atomic_int type for atomic operations */
-#if CYSIGNALS_C_ATOMIC || CYSIGNALS_CXX_ATOMIC
+#if defined(CYSIGNALS_C_ATOMIC) || defined(CYSIGNALS_CXX_ATOMIC)
 typedef volatile _Atomic int cy_atomic_int;
-#elif CYSIGNALS_STD_ATOMIC
+#elif defined(CYSIGNALS_STD_ATOMIC)
 #include <atomic>
 typedef volatile std::atomic<int> cy_atomic_int;
 #else
@@ -80,7 +80,7 @@ typedef struct
      * This is used by the sig_occurred function. */
     PyObject* exc_value;
 
-#if ENABLE_DEBUG_CYSIGNALS
+#ifdef ENABLE_DEBUG_CYSIGNALS
     int debug_level;
 #endif
 } cysigs_t;

--- a/src/cysignals/tests_helper.c
+++ b/src/cysignals/tests_helper.c
@@ -25,29 +25,29 @@
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
-#if HAVE_UNISTD_H
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if HAVE_SYS_MMAN_H
+#ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
-#if HAVE_SYS_TYPES_H
+#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#if HAVE_SYS_TIME_H
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#if HAVE_SYS_WAIT_H
+#ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#if HAVE_WINDOWS_H
+#ifdef HAVE_WINDOWS_H
 #include <windows.h>
 #endif
 
 
 static int on_alt_stack(void)
 {
-#if HAVE_SIGALTSTACK
+#ifdef HAVE_SIGALTSTACK
     stack_t oss;
     sigaltstack(NULL, &oss);
     return oss.ss_flags & SS_ONSTACK;
@@ -60,7 +60,7 @@ static int on_alt_stack(void)
 /* Wait ``ms`` milliseconds */
 static void ms_sleep(long ms)
 {
-#if HAVE_UNISTD_H
+#ifdef HAVE_UNISTD_H
     usleep(1000 * ms);
 #else
     Sleep(ms);
@@ -118,7 +118,7 @@ static void signals_after_delay(int signum, long ms, long interval, int n)
     fflush(stdout);
     fflush(stderr);
 
-#if !HAVE_KILL
+#ifndef HAVE_KILL
     /* On Windows, we just send the signal right away. This is because
      * there is no way to send a signal to an arbitrary process
      * (or thread). Raising the signal here decreases slightly the


### PR DESCRIPTION
Many macros are either `1` or undefined.

Instead of

    #if CYSIGNALS_ASM_CYSETJMP

we should correctly check

    #ifdef CYSIGNALS_ASM_CYSETJMP

See also: https://github.com/sagemath/cysignals/pull/134#discussion_r590435141