### PR TITLE
Add -y flag to conda create as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     - conda config --set always_yes True
     - conda info
 
-    - conda create --name test python=${PYTHON_VERSION}
+    - conda create -y --name test python=${PYTHON_VERSION}
     - conda activate test
     # We need the toolchain stuff to work around
     # https://github.com/conda/conda/issues/6030


### PR DESCRIPTION
For unknowable reasons this doesn't seem to be needed on the master
branch, but for some reason the 1.10.x branch builds hang without
this...