### PR TITLE
Try to fix AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,21 +11,24 @@ environment:
     # isn't covered by this document) at the time of writing.
     - os: Cygwin
       CYG_ROOT: "C:\\cygwin64"
-      PYTHON: "C:\\cygwin64\\bin"
+      PYTHON_PATH: "C:\\cygwin64\\bin"
       PYTHON_VERSION: "2.7"
       ARCH: x86_64
       MAKE: make
 
 before_build:
   - echo "Building Cysignals for %OS%"
-  - set PATH=%PYTHON%;%PYTHON%\\scripts;%TOOLSPATH%;%PATH%
+  - set PATH=%PYTHON_PATH%;%PYTHON_PATH%\\scripts;%TOOLSPATH%;%PATH%
   - echo %PATH%
   - ps: >-
       if ( "$Env:OS" -ieq "Cygwin" ) {
           $python = "python" + $Env:PYTHON_VERSION[0] + $Env:PYTHON_VERSION[2]
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
+              -RedirectStandardOutput out.txt -RedirectStandardError err.txt `
               -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++,libcrypt-devel"
+          Get-Content -Path out.txt
+          Get-Content -Path err.txt
       }
   - cd C:\projects\cysignals
   - python%PYTHON_VERSION% -c "import sys; print(sys.version); print(sys.platform); print(sys.path)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ before_build:
           Start-Process -NoNewWindow -Wait `
               -FilePath $Env:CYG_ROOT\setup-$Env:ARCH.exe `
               -RedirectStandardOutput out.txt -RedirectStandardError err.txt `
-              -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++,libcrypt-devel"
+              -ArgumentList "-q -P $python,$python-devel,$python-pip,gcc-core,gcc-g++,binutils,libcrypt-devel"
           Get-Content -Path out.txt
           Get-Content -Path err.txt
       }

--- a/configure.ac
+++ b/configure.ac
@@ -108,10 +108,20 @@ if test x$sigsetjmp = xyes; then
 fi
 
 AC_MSG_CHECKING([for assembly implementation of cysetjmp])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE(
+AC_RUN_IFELSE([AC_LANG_SOURCE(
     [
     #define CYSIGNALS_ASM_CYSETJMP 1
     #include "src/cysignals/cysetjmp.h"
+    int main(void) {
+        cyjmp_buf jmp_buf;
+        int ret = cysetjmp(jmp_buf);
+        if (ret != 0) {
+            return !ret;
+        }
+
+        cylongjmp(jmp_buf, 1);
+        return 1;
+    }
     ])],
     dnl YES
     [AC_MSG_RESULT([yes])]

--- a/configure.ac
+++ b/configure.ac
@@ -111,10 +111,13 @@ AC_MSG_CHECKING([for assembly implementation of cysetjmp])
 AC_RUN_IFELSE([AC_LANG_SOURCE(
     [
     #define CYSIGNALS_ASM_CYSETJMP 1
+    #include <unistd.h>
     #include "src/cysignals/cysetjmp.h"
     int main(void) {
         cyjmp_buf jmp_buf;
-        int ret = cysetjmp(jmp_buf);
+        int ret;
+        alarm(1);  // kill the process if it runs off into the weeds
+        ret = cysetjmp(jmp_buf);
         if (ret != 0) {
             return !ret;
         }


### PR DESCRIPTION
Fixes #143 

I'm not sure if this is the problem, but I think AppVeyor no longer supports "os:" (which was never well documented anyways).

Try OS as environment variable explicitly instead.

Also change the PYTHON environment variable to PYTHON_PATH which makes
its purpose a bit clearer.