### PR TITLE
use logging to log all exceptions

### DIFF
--- a/rundoctests.py
+++ b/rundoctests.py
@@ -10,6 +10,7 @@ import sys
 import doctest
 from doctest import DocTestParser, Example, SKIP
 from multiprocessing import Process
+import logging
 
 flags = doctest.ELLIPSIS
 timeout = 600
@@ -81,9 +82,8 @@ def testfile(file):
                                        optionflags=flags, parser=parser)
         if not failures:
             os._exit(0)
-    except BaseException as E:
-        print(E)
     finally:
+        logging.exception("Exception thrown while running cysignals doctests")
         os._exit(23)
 
 


### PR DESCRIPTION
#155 is difficult to figure out. The reason is simple. The exceptions in `rundoctests` are caught and printed with

    try:
        failures, _ = doctest.testfile(file, module_relative=False, optionflags=flags, parser=parser)
    if not failures:
        os._exit(0)
    except BaseExcept as E:
        print(E)
    finally:
        os._exit(23)

However, the exceptions thrown by `sig_on` are not of type `BaseExcept`. We use `logging.exception` instead.