### PR TITLE
Remove PARI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,6 @@ Requirements
 - Python >= 3.6
 - Cython >= 0.28
 - Sphinx >= 1.6 (for building the documentation)
-- PARI/GP (optional; for interfacing with the PARI/GP signal handler)
 
 Links
 -----
@@ -42,6 +41,12 @@ Links
 
 Changelog
 ---------
+
+1.12.0 (unreleased)
+^^^^^^^^^^^^^^^^^^^
+
+* Remove optional compile-time dependency on PARI/GP. [#166]
+
 
 1.11.4 (2023-10-07)
 ^^^^^^^^^^^^^^^^^^^

--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,6 @@ AC_CONFIG_FILES([src/cysignals/signals.pxd])
 
 AC_ARG_ENABLE(debug,
     AS_HELP_STRING([--enable-debug], [enable debug output]))
-AC_ARG_WITH(pari,
-    AS_HELP_STRING([--without-pari], [build without PARI support]))
 
 if test "$enable_debug" = yes; then
     AC_DEFINE([ENABLE_DEBUG_CYSIGNALS], 1, [Enable debug output])
@@ -29,21 +27,6 @@ AC_PROG_CXX()
 
 AC_CHECK_HEADERS([execinfo.h sys/mman.h sys/prctl.h time.h sys/wait.h windows.h])
 AC_CHECK_FUNCS([fork kill sigprocmask sigaltstack backtrace])
-
-
-have_pari=no
-if test "$with_pari" != "no"; then
-    AC_SEARCH_LIBS([pari_init], [pari], [
-        AC_CHECK_DECL([PARI_SIGINT_block],
-            [have_pari=yes], [],
-            [[#include <pari/pari.h>]])])
-fi
-
-if test "$have_pari" = "yes"; then
-    AC_DEFINE([HAVE_PARI], 1, [Define to 1 if PARI is fully supported.])
-elif test "$with_pari" = "yes"; then
-    AC_MSG_ERROR([PARI support requested but PARI was not found])
-fi
 
 AC_MSG_CHECKING([for emms instruction])
 # We add the "leal" instruction to reduce false positives in case some

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -54,14 +54,6 @@ Interrupt and signal handling for Cython
 #include <sys/prctl.h>
 #endif
 #include <Python.h>
-#if HAVE_PARI
-#include <pari/pari.h>
-#else
-/* Fake PARI variables */
-static int PARI_SIGINT_block = 0;
-static int PARI_SIGINT_pending = 0;
-#define paricfg_version NULL
-#endif
 
 // Custom signal handling of other packages.
 #define MAX_N_CUSTOM_HANDLERS 16
@@ -94,8 +86,6 @@ void custom_set_pending_signal(int sig){
 }
 
 #if HAVE_WINDOWS_H
-/* We must include <windows.h> after <pari.h>
- * See https://github.com/sagemath/cysignals/issues/107 */
 #include <windows.h>
 #endif
 #include "struct_signals.h"
@@ -295,7 +285,7 @@ static void cysigs_interrupt_handler(int sig)
 
     if (cysigs.sig_on_count > 0)
     {
-        if (!cysigs.block_sigint && !PARI_SIGINT_block && !custom_signal_is_blocked())
+        if (!cysigs.block_sigint && !custom_signal_is_blocked())
         {
             /* Raise an exception so Python can see it */
             do_raise_exception(sig);
@@ -318,7 +308,6 @@ static void cysigs_interrupt_handler(int sig)
     if (cysigs.interrupt_received != SIGHUP && cysigs.interrupt_received != SIGTERM)
     {
         cysigs.interrupt_received = sig;
-        PARI_SIGINT_pending = sig;
         custom_set_pending_signal(sig);
     }
 }
@@ -486,7 +475,6 @@ static void _sig_on_interrupt_received(void)
     do_raise_exception(cysigs.interrupt_received);
     cysigs.sig_on_count = 0;
     cysigs.interrupt_received = 0;
-    PARI_SIGINT_pending = 0;
     custom_signal_unblock();
 
 #if HAVE_SIGPROCMASK
@@ -499,11 +487,9 @@ static void _sig_on_interrupt_received(void)
 static void _sig_on_recover(void)
 {
     cysigs.block_sigint = 0;
-    PARI_SIGINT_block = 0;
     custom_signal_unblock();
     cysigs.sig_on_count = 0;
     cysigs.interrupt_received = 0;
-    PARI_SIGINT_pending = 0;
     custom_set_pending_signal(0);
 
 #if HAVE_SIGPROCMASK


### PR DESCRIPTION
As a follow-up on the merged PR
- #181 

... this PR removes the optional-compile dependency on pari as proposed in the discussion of https://github.com/sagemath/cypari2/pull/109.

This should be merged only after 
- [X] a Cysignals release 1.11.x has been made that includes #181 
- [ ] a CyPari2 release has been made that uses the general signal hook added in #181. --> 2.2.0

Resolves #125
