### PR TITLE
Upgrade cibuildwheel to 2.16.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,11 +19,8 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v2
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.0
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.11.2
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Cancel previous runs of this workflow for the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.16.0
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.0
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+        env:
+          # on pp310: build/src/cysignals/implementation.c:231:9: error: implicit declaration of function 'PyPyErr_SetInterrupt' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+          CIBW_SKIP: "pp31*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ['setuptools', 'Cython>=0.28, <3']
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will automatically build wheels for the recently released Python 3.11