### PR TITLE
Suppress fortify source globally.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ kwds = dict(include_dirs=[opj("src"),
             depends=depends,
             define_macros=macros,
             undef_macros=undef_macros,
-            extra_compile_args=["-pthread"],
+            extra_compile_args=["-pthread", "-Wp,-U_FORTIFY_SOURCE"],
             extra_link_args=["-pthread"],)
 
 extensions = [


### PR DESCRIPTION
Some distributions add `_FORTIFY_SOURCE` [globally](https://www.gnu.org/software/autoconf-archive/ax_add_fortify_source.html), which results in the compiler option `-Wp,-D_FORTIFY_SOURCE-2` being passed to the compiler. Sadly, this option is not overridden by the `undef_macros` setuptools parameter, as that only does `-U_FORTIFY_SOURCE` but the `-Wp` option [passes directly](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-Wp) to the preprocessor. Thus ArchLinux for example had to do a CFLAGS change in their distribution of the cysignals package, see [here](https://github.com/archlinux/svntogit-community/blob/packages/cysignals/trunk/PKGBUILD#L19). The package is not compilable by default on ArchLinux from pypi.

This PR fixes this issue, not in the nicest possible way, but certainly sufficiently. 

