### PR TITLE
Add pyproject.toml, remove Cython from setup_requires, install_requires

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -111,7 +111,7 @@ jobs:
         choco install make autoconf gcc-core gcc-g++ python3${{ matrix.python-version }}-devel --source cygwin
     - name: install dependencies
       run: |
-        C:\\tools\\cygwin\\bin\\bash -l -x -c 'export PATH=/usr/local/bin:/usr/bin && cd $(cygpath -u "$GITHUB_WORKSPACE") && python3.${{ matrix.python-version }} -m pip install setuptools cysignals Cython Sphinx flake8'
+        C:\\tools\\cygwin\\bin\\bash -l -x -c 'export PATH=/usr/local/bin:/usr/bin && cd $(cygpath -u "$GITHUB_WORKSPACE") && python3.${{ matrix.python-version }} -m pip install setuptools cysignals 'Cython<3' Sphinx flake8'
     - name: install
       run: |
         C:\\tools\\cygwin\\bin\\bash -l -x -c 'export PATH=/usr/local/bin:/usr/bin && cd $(cygpath -u "$GITHUB_WORKSPACE") && python3.${{ matrix.python-version }} setup.py build_ext -i'
@@ -241,7 +241,7 @@ jobs:
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
-          pip install setuptools Cython Sphinx flake8
+          pip install setuptools 'Cython<3' Sphinx flake8
     - name: Freeze pip
       run: |
           pip freeze
@@ -354,7 +354,7 @@ jobs:
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
-          pip install setuptools Cython Sphinx flake8
+          pip install setuptools 'Cython<3' Sphinx flake8
     - name: Freeze pip
       run: |
           pip freeze

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['setuptools', 'Cython>=0.28']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools', 'Cython>=0.28']
+requires = ['setuptools', 'Cython>=0.28, <3']

--- a/setup.py
+++ b/setup.py
@@ -201,9 +201,6 @@ setup(
     long_description=README,
     long_description_content_type='text/x-rst',
     classifiers=classifiers,
-    install_requires=["Cython>=0.28"],
-    setup_requires=["Cython>=0.28"],
-
     ext_modules=extensions,
     packages=["cysignals"],
     package_dir={"": "src"},


### PR DESCRIPTION
Fixes #171.

For now, we use "Cython < 3". 
Fixes for Cython 3 in separate PRs.
