### PR TITLE
.github/workflows/ci-sage.yml: Use reusable Sage workflow for macOS

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -152,16 +152,14 @@ jobs:
         make -j4 distcheck
 
   linux:
-    uses: mkoeppe/sage/.github/workflows/docker.yml@tox_2023_09
+    uses: sagemath/sage/.github/workflows/docker.yml@develop
     with:
       # FIXME: duplicated from env.TARGETS
       targets_pre:       build/make/Makefile
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cysignals,cypari" cysignals cypari
       targets_optional:  build/make/Makefile
-      sage_repo:         mkoeppe/sage
-      sage_ref:          tox_2023_09
-      #sage_repo:         sagemath/sage
-      #sage_ref:          develop
+      sage_repo:         sagemath/sage
+      sage_ref:          develop
       upstream_artifact: upstream
       # We prefix the image name with the SPKG name ("cysignals-") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
@@ -201,8 +199,7 @@ jobs:
         make -j4 distcheck
 
   macos:
-    # https://github.com/sagemath/sage/pull/36338
-    uses: mkoeppe/sage/.github/workflows/macos.yml@tox_2023_09
+    uses: sagemath/sage/.github/workflows/macos.yml@develop
     with:
       osversion_xcodeversion_toxenv_tuples: >-
         [["latest", "",           "homebrew-macos-usrlocal-minimal"],
@@ -213,9 +210,7 @@ jobs:
       targets_pre:       build/make/Makefile
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cysignals,cypari" cysignals cypari
       targets_optional:  build/make/Makefile
-      sage_repo:         mkoeppe/sage
-      sage_ref:          tox_2023_09
-      #sage_repo:         sagemath/sage
-      #sage_ref:          refs/pull/36110/merge
+      sage_repo:         sagemath/sage
+      sage_ref:          develop
       upstream_artifact: upstream
     needs: [dist, macos-without-sage]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -199,61 +199,19 @@ jobs:
         make -j4 distcheck
 
   macos:
-
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        os: [ macos-12 ]
-        tox_system_factor: [homebrew-macos-urlocal, conda-forge-macos]
-        tox_packages_factor: [minimal, standard]
-        xcode_version_factor: [default]
-
+    # https://github.com/sagemath/sage/pull/36338
+    uses: mkoeppe/sage/.github/workflows/macos.yml@tox_2023_09
+    with:
+      osversion_xcodeversion_toxenv_tuples: >-
+        [["latest", "",           "homebrew-macos-usrlocal-minimal"],
+         ["latest", "",           "homebrew-macos-usrlocal-standard"],
+         ["13",     "xcode_15.0", ""homebrew-macos-usrlocal-standard"],
+         ["latest", "",           "conda-forge-macos-standard"]]
+      # FIXME: duplicated from env.TARGETS
+      targets_pre:       build/make/Makefile
+      targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cysignals,cypari" cysignals cypari
+      targets_optional:  build/make/Makefile
+      sage_repo:         sagemath/sage
+      sage_ref:          refs/pull/36110/merge
+      upstream_artifact: upstream
     needs: [dist, macos-without-sage]
-
-    env:
-      TOX_ENV: local-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}
-      LOGS_ARTIFACT_NAME: logs-commit-${{ github.sha }}-tox-local-${{ matrix.tox_system_factor }}-${{ matrix.tox_packages_factor }}-${{ matrix.os }}-xcode_${{ matrix.xcode_version_factor }}
-      DOCKER_TARGETS: configured with-targets with-targets-optional
-
-    steps:
-
-      - name: Select Xcode version
-        run: |
-          if [ ${{ matrix.xcode_version_factor }} != default ]; then sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version_factor }}.app; fi
-      - name: Check out SageMath
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.SAGE_REPO }}
-          ref: ${{ env.SAGE_REF }}
-      - uses: actions/download-artifact@v2
-        with:
-          path: upstream
-          name: upstream
-      - name: Update Sage packages from upstream artifact
-        run: |
-          (export PATH=$(pwd)/build/bin:$PATH; (cd upstream && bash -x update-pkgs.sh) && git diff)
-
-      - name: Install test prerequisites
-        run: |
-          brew install tox
-      - name: Build and test with tox
-        # We use a high parallelization on purpose in order to catch possible parallelization bugs in the build scripts.
-        # For doctesting, we use a lower parallelization to avoid timeouts.
-        run: |
-          MAKE="make -j12" tox -e $TOX_ENV -- SAGE_NUM_THREADS=4 $TARGETS
-      - name: Prepare logs artifact
-        run: |
-          mkdir -p "artifacts/$LOGS_ARTIFACT_NAME"; cp -r .tox/*/log "artifacts/$LOGS_ARTIFACT_NAME"
-        if: always()
-      - uses: actions/upload-artifact@v1
-        with:
-          path: artifacts
-          name: ${{ env.LOGS_ARTIFACT_NAME }}
-        if: always()
-      - name: Print out logs for immediate inspection
-        # and markup the output with GitHub Actions logging commands
-        run: |
-          .github/workflows/scan-logs.sh "artifacts/$LOGS_ARTIFACT_NAME"
-        if: always()

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -151,15 +151,17 @@ jobs:
         make -j4 check-all
         make -j4 distcheck
 
-  docker:
-    uses: sagemath/sage/.github/workflows/docker.yml@develop
+  linux:
+    uses: mkoeppe/sage/.github/workflows/docker.yml@tox_2023_09
     with:
       # FIXME: duplicated from env.TARGETS
       targets_pre:       build/make/Makefile
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cysignals,cypari" cysignals cypari
       targets_optional:  build/make/Makefile
-      sage_repo:         sagemath/sage
-      sage_ref:          develop
+      sage_repo:         mkoeppe/sage
+      sage_ref:          tox_2023_09
+      #sage_repo:         sagemath/sage
+      #sage_ref:          develop
       upstream_artifact: upstream
       # We prefix the image name with the SPKG name ("cysignals-") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
@@ -205,13 +207,15 @@ jobs:
       osversion_xcodeversion_toxenv_tuples: >-
         [["latest", "",           "homebrew-macos-usrlocal-minimal"],
          ["latest", "",           "homebrew-macos-usrlocal-standard"],
-         ["13",     "xcode_15.0", ""homebrew-macos-usrlocal-standard"],
+         ["13",     "xcode_15.0", "homebrew-macos-usrlocal-standard"],
          ["latest", "",           "conda-forge-macos-standard"]]
       # FIXME: duplicated from env.TARGETS
       targets_pre:       build/make/Makefile
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cysignals,cypari" cysignals cypari
       targets_optional:  build/make/Makefile
-      sage_repo:         sagemath/sage
-      sage_ref:          refs/pull/36110/merge
+      sage_repo:         mkoeppe/sage
+      sage_ref:          tox_2023_09
+      #sage_repo:         sagemath/sage
+      #sage_ref:          refs/pull/36110/merge
       upstream_artifact: upstream
     needs: [dist, macos-without-sage]


### PR DESCRIPTION
We switch the Sage portability/integration CI for macOS to using a reusable workflow introduced in https://github.com/sagemath/sage/pull/36338

The new version has up-to-date macOS platforms and auto-applies blocker PRs in sagemath/sage (we also switch the Linux workflow to it)


