### PR TITLE
fix cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ fi
 AC_MSG_CHECKING([for emms instruction])
 # We add the "leal" instruction to reduce false positives in case some
 # non-x86 architecture also has an "emms" instruction.
-AC_RUN_IFELSE([AC_LANG_PROGRAM([[]], [[asm("leal (%eax), %eax; emms");]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[asm("leal (%eax), %eax; emms");]])],
     dnl YES
     [AC_MSG_RESULT([yes])]
     AC_DEFINE(HAVE_EMMS, 1, [Define to 1 if your processor understands the "emms" instruction.])
@@ -84,6 +84,9 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
     ,
     dnl NO
     [AC_MSG_RESULT([no])]
+    ,
+    [AC_MSG_RESULT([cross, assume yes])]
+    sigsetjmp=yes
 )
 
 AC_MSG_CHECKING([for GNU libc])


### PR DESCRIPTION
This PR allows for cross compilation, by running `./configure` before building using the standard cross compile flags.

Using this change I'm able to cross compile cysignals and dependents (cypari2, fpylll, primecountpy, pplpy) in several arm architectures. See: https://github.com/void-linux/void-packages/pull/46738.