### PR TITLE
cythonize: discard now obsoleted directive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,6 @@ class build_ext(_build_ext):
                 compiler_directives=dict(
                     binding=True,
                     language_level=2,
-                    legacy_implicit_noexcept=True,
                     ))
 
 


### PR DESCRIPTION
Description: upstream: fix: obsoleted compiler directive: discard
 This patch discards the now obsolete compiler directive
 `legacy_implicit_noexcept`.
Origin: vendor, Debian
Author: Jerome Benoit <calculus_AT+rezozer+DOT_net>
Last-Update: 2023-11-04