### PR TITLE
Initial patch for emscripten / pyodide support

### DIFF
--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -531,7 +531,7 @@ static void _sig_off_warning(const char* file, int line)
 
 static void setup_alt_stack(void)
 {
-#if HAVE_SIGALTSTACK
+#if HAVE_SIGALTSTACK && !defined(__EMSCRIPTEN__)
     /* Space for the alternate signal stack. The size should be
      * of the form MINSIGSTKSZ + constant. The constant is chosen rather
      * ad hoc but sufficiently large.
@@ -576,7 +576,9 @@ static void setup_cysignals_handlers(void)
      * After setting up the trampoline, we reset the signal mask. */
     sigprocmask(SIG_BLOCK, &sa.sa_mask, &default_sigmask);
 #endif
+#if !defined(__EMSCRIPTEN__)
     setup_trampoline();
+#endif
 #if HAVE_SIGPROCMASK
     sigprocmask(SIG_SETMASK, &default_sigmask, &sigmask_with_sigint);
 #endif


### PR DESCRIPTION
On the emscripten / pyodide platform, there is limited support for POSIX signals. 
- As noted in https://docs.python.org/3/library/signal.html#general-rules, in CPython on this platform, "signals are emulated and therefore behave differently. Several functions and signals are not available on these platforms."
- https://github.com/python/cpython/blob/main/Python/emscripten_signal.c
- https://github.com/python/cpython/blob/main/Modules/signalmodule.c
- https://github.com/python/cpython/blob/main/Include/internal/pycore_emscripten_signal.h

Building `cysignals` succeeds, but `import cysignals` exits immediately because functions `sigaltstack` and `pthread_create` error out.

Here we attempt to provide basic support this platform.

- This is to support https://github.com/pyodide/pyodide/pull/4407