### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -34,6 +34,10 @@ cimport cython
 import sys
 from gc import collect
 
+IF UNAME_SYSNAME == "Windows":
+    DEF SIGHUP = 1000
+    DEF SIGALRM = 1000
+    DEF SIGBUS = 1000
 
 cdef extern from "implementation.c":
     cysigs_t cysigs


### PR DESCRIPTION
Based on https://github.com/sagemath/cysignals/pull/206, we make cysignals compile nicely on Windows.

Fixes https://github.com/sagemath/cysignals/issues/201 and fixes https://github.com/sagemath/cysignals/issues/198