### PR TITLE
Fix build issues

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -15,13 +15,6 @@ print(cysignals.__file__.replace('__init__.py', ''))
 ).stdout().strip()
 cysignals = declare_dependency(include_directories: inc_cysignals)
 
-# Make declarations in Cython code available to C include files
-add_project_arguments(
-  '-X preliminary_late_includes_cy28=True',
-  language: 'cython',
-)
-
-
 py.extension_module('cysignals_example',
   sources: ['cysignals_example.pyx'],
   install: true,

--- a/meson.build
+++ b/meson.build
@@ -22,11 +22,6 @@ add_project_arguments('-DCYTHON_CLINE_IN_TRACEBACK=0', language: 'c')
 # Disable sanity checking in GNU libc
 # This is required because of false positives in the longjmp() check
 add_project_arguments('-U_FORTIFY_SOURCE', language: 'c')
-# Make declarations in Cython code available to C include files
-add_project_arguments(
-  '-X preliminary_late_includes_cy28=True',
-  language: 'cython',
-)
 
 # Platform-specific settings
 if is_cygwin

--- a/src/cysignals/signals.pxd
+++ b/src/cysignals/signals.pxd
@@ -1,3 +1,4 @@
+# cython: preliminary_late_includes_cy28=True
 #*****************************************************************************
 #  cysignals is free software: you can redistribute it and/or modify it
 #  under the terms of the GNU Lesser General Public License as published

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -1,3 +1,4 @@
+# cython: preliminary_late_includes_cy28=True
 r"""
 Interrupt and signal handling
 

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -1,3 +1,4 @@
+# cython: preliminary_late_includes_cy28=True
 """
 Test interrupt and signal handling
 


### PR DESCRIPTION
The migration to the meson build system, causes failures when building packages that depend on `cysignals` but don't use meson (i.e. they use `setup.py`).

Closes: #212 