### PR TITLE
Fix incorrect datetime.UTC access

### DIFF
--- a/src/scripts/cysignals-CSI
+++ b/src/scripts/cysignals-CSI
@@ -37,8 +37,8 @@ import tempfile
 import sysconfig
 import site
 
+import datetime
 from argparse import ArgumentParser
-from datetime import datetime
 from shutil import which
 import importlib.resources as importlib_resources
 
@@ -130,8 +130,8 @@ def prune_old_logs(directory, days):
     """
     for filename in os.listdir(directory):
         filename = os.path.join(directory, filename)
-        mtime = datetime.fromtimestamp(os.path.getmtime(filename), datetime.UTC)
-        age = datetime.now(datetime.UTC) - mtime
+        mtime = datetime.datetime.fromtimestamp(os.path.getmtime(filename), datetime.UTC)
+        age = datetime.datetime.now(datetime.UTC) - mtime
         if age.days >= days:
             try:
                 os.unlink(filename)


### PR DESCRIPTION
The old code is incorrect, `datetime.UTC` is an attribute of the module, not the type.

p/s looks like this is new in Python 3.11? do we really want to drop support for ≤ Python 3.10? https://docs.python.org/3/library/datetime.html#datetime.UTC