### PR TITLE
Fix warnings (C and cython)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
           pip install --upgrade -r requirements.txt
           pip install --upgrade ninja
     - name: Build
-      run: pip install --no-build-isolation --config-settings=builddir=builddir .
+      run: pip install -v --no-build-isolation --config-settings=builddir=builddir .
     - name: Test
       run: meson test --print-errorlogs -C builddir

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cysignals', 'c', 'cpp', 'cython',
-  default_options: ['warning_level=3', 'cpp_std=c++17']
+  default_options: ['warning_level=2', 'cpp_std=c++17']
 )
 
 # Python

--- a/src/cysignals/alarm.pyx
+++ b/src/cysignals/alarm.pyx
@@ -80,7 +80,7 @@ def cancel_alarm():
     setitimer_real(0)
 
 
-cdef inline void setitimer_real(double x):
+cdef inline void setitimer_real(double x) noexcept:
     cdef itimerval itv
     itv.it_interval.tv_sec = 0
     itv.it_interval.tv_usec = 0

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -492,7 +492,7 @@ static void cysigs_signal_handler(int sig)
  * fact, POSIX recommends threads in
  * http://pubs.opengroup.org/onlinepubs/009695299/functions/makecontext.html
  */
-static void* _sig_on_trampoline(void* dummy)
+static void* _sig_on_trampoline(CYTHON_UNUSED void* dummy)
 {
     register int sig;
 
@@ -523,7 +523,7 @@ static void setup_trampoline(void)
     size_t trampolinestacksize = 1 << 17;
 
 #ifdef PTHREAD_STACK_MIN
-    if (trampolinestacksize < PTHREAD_STACK_MIN)
+    if (trampolinestacksize < (size_t) PTHREAD_STACK_MIN)
         trampolinestacksize = PTHREAD_STACK_MIN;
 #endif
     trampolinestack = malloc(trampolinestacksize + 4096);

--- a/src/cysignals/macros.h
+++ b/src/cysignals/macros.h
@@ -112,7 +112,7 @@ extern "C" {
 /*
  * Set message, return 0 if we need to cysetjmp(), return 1 otherwise.
  */
-static inline int _sig_on_prejmp(const char* message, const char* file, int line)
+static inline int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, CYTHON_UNUSED int line)
 {
     cysigs.s = message;
 #if ENABLE_DEBUG_CYSIGNALS

--- a/src/cysignals/meson.build
+++ b/src/cysignals/meson.build
@@ -28,6 +28,7 @@ foreach name, pyx : extensions
     py.extension_module(name,
         pyx,
         include_directories: [include_directories('.'), src],
+        cython_args: ['-Wextra'],
         dependencies: [py_dep, threads_dep],
         install: true,
         subdir: 'cysignals'

--- a/src/cysignals/pysignals.pyx
+++ b/src/cysignals/pysignals.pyx
@@ -441,7 +441,6 @@ cdef class containsignals:
     cdef sigset_t unblock
 
     def __init__(self, signals=None):
-        cdef int s
         if signals is None:
             self.signals = [s for s in range(1, 32) if s != SIGKILL and s != SIGSTOP]
         else:

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -198,9 +198,9 @@ cdef int sig_raise_exception "sig_raise_exception"(int sig, const char* msg) exc
         PyErr_Format(SystemError, "unknown signal number %i", sig)
 
     # Save exception in cysigs.exc_value
-    cdef PyObject* typ
-    cdef PyObject* val
-    cdef PyObject* tb
+    cdef PyObject* typ = NULL
+    cdef PyObject* val = NULL
+    cdef PyObject* tb = NULL
     PyErr_Fetch(&typ, &val, &tb)
     PyErr_NormalizeException(&typ, &val, &tb)
     Py_XINCREF(val)

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -246,10 +246,10 @@ def sig_print_exception(sig, msg=None):
 
     try:
         sig_raise_exception(sig, m)
-    except BaseException as e:
+    except BaseException:
         # Print exception to stdout without traceback
         import sys, traceback
-        typ, val, tb = sys.exc_info()
+        typ, val, _ = sys.exc_info()
         traceback.print_exception(typ, val, None, file=sys.stdout, chain=False)
 
 

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -1,4 +1,4 @@
-# cython: preliminary_late_includes_cy28=True
+# cython: preliminary_late_includes_cy28=True, show_performance_hints=False
 """
 Test interrupt and signal handling
 

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -1280,7 +1280,7 @@ def test_thread_sig_block(long delay=DEFAULT_DELAY):
         >>> test_thread_sig_block()
 
     """
-    cdef pthread_t t1, t2
+    cdef pthread_t t1 = 0, t2 = 0
     with nogil:
         sig_on()
         if pthread_create(&t1, NULL, func_thread_sig_block, NULL):

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -254,7 +254,7 @@ def test_sig_str(long delay=DEFAULT_DELAY):
         signal_after_delay(SIGABRT, delay)
         infinite_loop()
 
-cdef c_test_sig_on_cython() noexcept:
+cdef c_test_sig_on_cython():
     sig_on()
     infinite_loop()
 

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -202,7 +202,7 @@ def subpython_err(command, **kwds):
     """
     argv = [sys.executable, '-c', command]
     P = Popen(argv, stdout=PIPE, stderr=PIPE, universal_newlines=True, **kwds)
-    (out, err) = P.communicate()
+    (_, err) = P.communicate()
     sys.stdout.write(err)
 
 
@@ -982,7 +982,7 @@ def test_sig_occurred_dealloc():
         No current exception
 
     """
-    x = DeallocDebug()
+    _ = DeallocDebug()
     sig_str("test_sig_occurred_dealloc()")
     abort()
 
@@ -1160,9 +1160,8 @@ def sig_on_bench():
         >>> sig_on_bench()
 
     """
-    cdef int i
     with nogil:
-        for i in range(1000000):
+        for _ in range(1000000):
             sig_on()
             sig_off()
 
@@ -1176,9 +1175,8 @@ def sig_check_bench():
         >>> sig_check_bench()
 
     """
-    cdef int i
     with nogil:
-        for i in range(1000000):
+        for _ in range(1000000):
             sig_check()
 
 
@@ -1298,8 +1296,7 @@ def test_thread_sig_block(long delay=DEFAULT_DELAY):
 
 cdef void* func_thread_sig_block(void* ignored) noexcept with gil:
     # This is executed by the two threads spawned by test_thread_sig_block()
-    cdef int n
-    for n in range(1000000):
+    for _ in range(1000000):
         sig_block()
         if not (1 <= cysigs.block_sigint <= 2):
             PyErr_SetString(RuntimeError, "sig_block() is not thread-safe")

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -58,8 +58,12 @@ cdef extern from "<pthread.h>" nogil:
 
 
 cdef extern from *:
-    # disable warning (variable might be clobbered by longjmp)
-    '#pragma GCC diagnostic ignored "-Wclobbered"'
+    """
+    #if defined(__GNUC__) && !defined(__clang__)
+    // disable warning (variable might be clobbered by longjmp)
+    #pragma GCC diagnostic ignored "-Wclobbered"
+    #endif
+    """
     ctypedef int volatile_int "volatile int"
 
 

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -58,6 +58,8 @@ cdef extern from "<pthread.h>" nogil:
 
 
 cdef extern from *:
+    # disable warning (variable might be clobbered by longjmp)
+    '#pragma GCC diagnostic ignored "-Wclobbered"'
     ctypedef int volatile_int "volatile int"
 
 
@@ -101,6 +103,9 @@ cdef void dereference_null_pointer() noexcept nogil:
     cdef volatile_int* ptr = <volatile_int*>(0)
     ptr[0] += 1
 
+# disable warning (infinite recursion in stack_overflow)
+cdef extern from *:
+    '#pragma GCC diagnostic ignored "-Winfinite-recursion"'
 
 cdef int stack_overflow(volatile_int* x=NULL) noexcept nogil:
     cdef volatile_int a = 0


### PR DESCRIPTION
This PR fixes warnings when building and testing

- **avoid C warnings**
- **cython warnings: disable performance hints in tests.pyx**
- **cython warnings: enable -Wextra**
- **cython warnings: avoid unused variables**
- **cython warnings: avoid maybe uninitialized**
- **reload cysignals handlers in tests.pyx**
- **tests::c_test_sig_on_cython: should not be noexcept**
- **alarm::setitimer_real: doesn't raise exceptions**
