### PR TITLE
Use Py_CLEAR() to avoid a data race (#221)

### DIFF
--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -25,7 +25,7 @@ See ``tests.pyx`` for extensive tests.
 
 from libc.signal cimport *
 from libc.stdio cimport freopen, stdin
-from cpython.ref cimport Py_XINCREF, Py_XDECREF
+from cpython.ref cimport Py_XINCREF, Py_CLEAR
 from cpython.exc cimport (PyErr_Occurred, PyErr_NormalizeException,
         PyErr_Fetch, PyErr_Restore)
 from cpython.version cimport PY_MAJOR_VERSION
@@ -204,7 +204,7 @@ cdef int sig_raise_exception "sig_raise_exception"(int sig, const char* msg) exc
     PyErr_Fetch(&typ, &val, &tb)
     PyErr_NormalizeException(&typ, &val, &tb)
     Py_XINCREF(val)
-    Py_XDECREF(cysigs.exc_value)
+    Py_CLEAR(cysigs.exc_value)
     cysigs.exc_value = val
     PyErr_Restore(typ, val, tb)
 
@@ -362,8 +362,7 @@ cdef void verify_exc_value() noexcept:
     """
     if cysigs.exc_value.ob_refcnt == 1:
         # No other references => exception is certainly gone
-        Py_XDECREF(cysigs.exc_value)
-        cysigs.exc_value = NULL
+        Py_CLEAR(cysigs.exc_value)
         return
 
     if PyErr_Occurred() is not NULL:
@@ -394,8 +393,7 @@ cdef void verify_exc_value() noexcept:
         pass
     else:
         if <PyObject*>handled is cysigs.exc_value:
-            Py_XDECREF(cysigs.exc_value)
-            cysigs.exc_value = NULL
+            Py_CLEAR(cysigs.exc_value)
             return
 
     # To be safe, we run the garbage collector because it may clear
@@ -411,5 +409,4 @@ cdef void verify_exc_value() noexcept:
     # called again during garbage collection it might have already been set
     # to NULL; see https://github.com/sagemath/cysignals/issues/126
     if cysigs.exc_value != NULL and cysigs.exc_value.ob_refcnt == 1:
-        Py_XDECREF(cysigs.exc_value)
-        cysigs.exc_value = NULL
+        Py_CLEAR(cysigs.exc_value)


### PR DESCRIPTION
Seems to fix #221

It turns out that
```python
        Py_XDECREF(cysigs.exc_value)
        cysigs.exc_value = NULL
```
is unsafe, if the code is interrupted in between the two statements [0].

This is what happens in #221. Then `verify_exc_value()` is called again with
`cysigs.exc_value.ob_refcnt=0`, breaking badly. Later on this causes
`verify_exc_value()` to be called with `cysigs.interrupt_received=1` which
should not happen.

Using instead the safe macro `Py_CLEAR()` seems to fix the issue.


[0] See the warning in
https://docs.python.org/3/c-api/refcounting.html#c.Py_DECREF
and see also
https://docs.python.org/3/c-api/refcounting.html#c.Py_CLEAR
