### PR TITLE
A few improvements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-13', 'macos-latest', 'ubuntu-latest', 'windows-latest']
-        python-version: ['3.10', '3.11', '3.12', '3.13-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Set up the repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build & Test
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   ci:
-    name: CI (${{ matrix.os }} with Python ${{ matrix.python-version }})
+    name: ${{ matrix.os }} with python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,37 +51,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cygwin:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version-start: [python-3]
-        python-version: [9]
-    steps:
-    - run: |
-        git config --global core.autocrlf false
-        git config --global core.symlinks true
-    - name: Set up the repository
-      uses: actions/checkout@v4
-      with:
-          submodules: recursive
-          fetch-depth: 0
-    - name: Set up Cygwin
-      uses: egor-tensin/setup-cygwin@v4
-      with:
-        packages: gcc-core gcc-g++ python3${{ matrix.python-version }}-devel ninja pkgconf
-    - name: Install dependencies
-      shell: C:\tools\cygwin\bin\bash.exe --norc -eo pipefail -o igncr '{0}'
-      run: |
-        python3.${{ matrix.python-version }} -m pip install --upgrade pip
-        python3.${{ matrix.python-version }} -m pip install --upgrade -r ./requirements.txt
-    - name: Build and check
-      shell: C:\tools\cygwin\bin\bash.exe --norc -eo pipefail -o igncr '{0}'
-      run: |
-        pip install --no-build-isolation --config-settings=builddir=builddir .
-        meson test --print-errorlogs -C builddir
-
   ci:
     name: CI (${{ matrix.os }} with Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,5 @@
 name: CI
 
-## This GitHub Actions workflow provides:
-##
-##  - portability testing, by building and testing this project on many platforms
-##    (Linux variants and Cygwin), each with two configurations (installed packages),
-##
-##  - continuous integration, by building and testing other software
-##    that depends on this project.
-##
-## It runs on every pull request and push of a tag to the GitHub repository.
-##
-## The testing can be monitored in the "Actions" tab of the GitHub repository.
-##
-## After all jobs have finished (or are canceled) and a short delay,
-## tar files of all logs are made available as "build artifacts".
-##
-## This GitHub Actions workflow uses the portability testing framework
-## of SageMath (https://www.sagemath.org/).  For more information, see
-## https://doc.sagemath.org/html/en/developer/portability_testing.html
-
-## The workflow consists of two jobs:
-##
-##  - First, it builds a source distribution of the project
-##    and generates a script "update-pkgs.sh".  It uploads them
-##    as a build artifact named upstream.
-##
-##  - Second, it checks out a copy of the SageMath source tree.
-##    It downloads the upstream artifact and replaces the project's
-##    package in the SageMath distribution by the newly packaged one
-##    from the upstream artifact, by running the script "update-pkgs.sh".
-##    Then it builds a small portion of the Sage distribution.
-##
-## Many copies of the second step are run in parallel for each of the tested
-## systems/configurations.
-
-#on: [push, pull_request]
-
 on:
   pull_request:
     types: [opened, synchronize]

--- a/meson.build
+++ b/meson.build
@@ -104,7 +104,7 @@ subdir('src')
 
 pytest = py_module.find_installation(modules: ['pytest'], required: false)
 if pytest.found()
-  test('pytest', pytest, args: ['-m', 'pytest'], workdir: meson.current_source_dir(), timeout: 300)
+  test('pytest', pytest, args: ['-m', 'pytest'], workdir: meson.current_source_dir(), timeout: 300, verbose: true, is_parallel: false)
 else
   message('pytest not found, skipping tests')
 endif


### PR DESCRIPTION
- **ci.yml: remove cygwin (broken, see #218)**
- **ci.yml: remove outdated comment**
- **ci.yml: improve names for display**
- **ci.yml: python 3.13 is released**
- **meson.build: make pytest verbose**

A few minor improvements in ci.yml, including removing cygwin which is outdated and broken, so we can get CI passing.
Also make it so meson test will print the output of pytest as it is going.

This is tested in https://github.com/tornaria/cysignals/pull/1

I wonder if we should add `ubuntu-24.04-arm` to the matrix so we test linux arm64? (note that arm64 is tested in macos-latest)

@dimpase @tobiasdiez

Replaces: #218
