### PR TITLE
Throttle garbage collector frequency in sig_occurred

### DIFF
--- a/src/cysignals/signals.pxd
+++ b/src/cysignals/signals.pxd
@@ -16,6 +16,7 @@
 #*****************************************************************************
 
 from cpython.object cimport PyObject
+from posix.time cimport timespec
 
 cdef extern from *:
     int unlikely(int) nogil  # Defined by Cython
@@ -29,6 +30,7 @@ cdef extern from "struct_signals.h":
         cy_atomic_int block_sigint
         const char* s
         PyObject* exc_value
+        timespec gc_pause_until
 
 
 cdef extern from "macros.h" nogil:

--- a/src/cysignals/struct_signals.h
+++ b/src/cysignals/struct_signals.h
@@ -26,6 +26,7 @@
 #include <setjmp.h>
 #include <signal.h>
 #include <Python.h>
+#include <sys/time.h>
 
 
 /* Choose sigjmp/longjmp variant */
@@ -91,6 +92,10 @@ typedef struct
     /* Reference to the exception object that we raised (NULL if none).
      * This is used by the sig_occurred function. */
     PyObject* exc_value;
+
+    /* Time until calling garbage collector is allowed. Using monotonic clock.
+     * See https://github.com/sagemath/cysignals/issues/215. */
+    struct timespec gc_pause_until;
 
 #if ENABLE_DEBUG_CYSIGNALS
     int debug_level;


### PR DESCRIPTION
Would fix https://github.com/sagemath/cysignals/issues/215 .

(Actually it's only a workaround until https://github.com/sagemath/sage/issues/24986 is fixed the correct way i.e. catch the exception on Sage side and avoid destructing the relevant objects. Still, I don't think there's any case where running garbage collector repeatedly rapidly is desirable.)