### PR TITLE
Reinstall signal handler when Python signal handler called

### DIFF
--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -681,7 +681,14 @@ static void setup_cysignals_handlers(void)
     sigprocmask(SIG_SETMASK, &default_sigmask, &sigmask_with_sigint);
 #endif
 
-    /* Install signal handlers */
+    /* Install signal handlers. We need a separate C-level interrupt handler
+     * apart from the Python-level interrupt handler because Python-level
+     * interrupt handler will not be called inside Cython code.
+     * See init_cysignals and python_check_interrupt for an explanation.
+     * A downside is the C-level interrupt handler will be overwritten
+     * when signal(SIGINT, getsignal(SIGINT)) is executed, in that case
+     * init_cysignals() need to be called again.
+     */
     /* Handlers for interrupt-like signals */
     sa.sa_handler = cysigs_interrupt_handler;
     sa.sa_flags = 0;

--- a/src/cysignals/signals.pxd
+++ b/src/cysignals/signals.pxd
@@ -26,6 +26,7 @@ cdef extern from "struct_signals.h":
 
     ctypedef struct cysigs_t:
         cy_atomic_int sig_on_count
+        cy_atomic_int interrupt_received
         cy_atomic_int block_sigint
         const char* s
         PyObject* exc_value

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -353,6 +353,12 @@ def python_check_interrupt(sig, frame):
     ``implementation.c``.
     """
     sig_check()
+    # If this line is reached, a possibility is that something called
+    # signal(SIGINT, getsignal(SIGINT)), which cause cysigs_interrupt_handler
+    # to not be called. We reinstall the C-level signal handler.
+    init_cysignals()
+    cysigs.interrupt_received = sig
+    sig_check()
 
 
 cdef void verify_exc_value() noexcept:


### PR DESCRIPTION
This would fix https://github.com/sagemath/sage/issues/39601 . Not sure if it has any downside.