### PR TITLE
Fix the atomicity of cy_atomic_int

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,9 +82,9 @@ config.set('CYSIGNALS_USE_SIGSETJMP', (setjmp_saves_mask or gnulibc) ? 1 : 0)
 
 # Check for atomic operations
 # for _Atomic in C code
-config.set('CYSIGNALS_C_ATOMIC', cc.links('int main() { static _Atomic int x; return 0; }') ? 1 : 0)
+config.set('CYSIGNALS_C_ATOMIC', cc.links('int main(void) { static _Atomic int x; return 0; }') ? 1 : 0)
 # for _Atomic with OpenMP in C code
-config.set('CYSIGNALS_C_ATOMIC_WITH_OPENMP', cc.links('int main() { static _Atomic int x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
+config.set('CYSIGNALS_C_ATOMIC_WITH_OPENMP', cc.links('int main(void) { static _Atomic int x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
 # for _Atomic in C++ code
 config.set('CYSIGNALS_CXX_ATOMIC', cxx.links('int main() { static _Atomic int x; return 0; }') ? 1 : 0)
 # for _Atomic with OpenMP in C++ code

--- a/meson.build
+++ b/meson.build
@@ -82,17 +82,17 @@ config.set('CYSIGNALS_USE_SIGSETJMP', (setjmp_saves_mask or gnulibc) ? 1 : 0)
 
 # Check for atomic operations
 # for _Atomic in C code
-config.set('CYSIGNALS_C_ATOMIC', cc.links('static _Atomic int x;') ? 1 : 0)
+config.set('CYSIGNALS_C_ATOMIC', cc.links('int main() { static _Atomic int x; return 0; }') ? 1 : 0)
 # for _Atomic with OpenMP in C code
-config.set('CYSIGNALS_C_ATOMIC_WITH_OPENMP', cc.links('static _Atomic int x;', args: ['-fopenmp']) ? 1 : 0)
+config.set('CYSIGNALS_C_ATOMIC_WITH_OPENMP', cc.links('int main() { static _Atomic int x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
 # for _Atomic in C++ code
-config.set('CYSIGNALS_CXX_ATOMIC', cxx.links('static _Atomic int x;') ? 1 : 0)
+config.set('CYSIGNALS_CXX_ATOMIC', cxx.links('int main() { static _Atomic int x; return 0; }') ? 1 : 0)
 # for _Atomic with OpenMP in C++ code
-config.set('CYSIGNALS_CXX_ATOMIC_WITH_OPENMP', cxx.links('static _Atomic int x;', args: ['-fopenmp']) ? 1 : 0)
+config.set('CYSIGNALS_CXX_ATOMIC_WITH_OPENMP', cxx.links('int main() { static _Atomic int x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
 # for std::atomic in C++ code
-config.set('CYSIGNALS_STD_ATOMIC', cxx.links('#include <atomic>\nstatic std::atomic<int> x;') ? 1 : 0)
+config.set('CYSIGNALS_STD_ATOMIC', cxx.links('#include <atomic>\nint main() { static std::atomic<int> x; return 0; }') ? 1 : 0)
 # for std::atomic with OpenMP in C++ code
-config.set('CYSIGNALS_STD_ATOMIC_WITH_OPENMP', cxx.links('#include <atomic>\nstatic std::atomic<int> x;', args: ['-fopenmp']) ? 1 : 0)
+config.set('CYSIGNALS_STD_ATOMIC_WITH_OPENMP', cxx.links('#include <atomic>\nint main() { static std::atomic<int> x; return 0; }', args: ['-fopenmp']) ? 1 : 0)
 
 if is_windows
   threads_dep = []

--- a/src/cysignals/struct_signals.h
+++ b/src/cysignals/struct_signals.h
@@ -41,14 +41,23 @@
 
 
 /* Define a cy_atomic_int type for atomic operations */
-#if CYSIGNALS_C_ATOMIC || CYSIGNALS_CXX_ATOMIC
-typedef volatile _Atomic int cy_atomic_int;
-#elif CYSIGNALS_STD_ATOMIC
+#if __cplusplus
+#if CYSIGNALS_STD_ATOMIC
 #include <atomic>
 typedef volatile std::atomic<int> cy_atomic_int;
+#elif CYSIGNALS_CXX_ATOMIC
+typedef volatile _Atomic int cy_atomic_int;
 #else
 /* The type sig_atomic_t is not really atomic, but it's the best we have */
 typedef volatile sig_atomic_t cy_atomic_int;
+#endif
+#else
+#if CYSIGNALS_C_ATOMIC
+typedef volatile _Atomic int cy_atomic_int;
+#else
+/* The type sig_atomic_t is not really atomic, but it's the best we have */
+typedef volatile sig_atomic_t cy_atomic_int;
+#endif
 #endif
 
 


### PR DESCRIPTION
When building sage, `meson.build` incorrectly sets all `CYSIGNALS_*` macros to 0 because of lacks of `main` function, which leads to a non-atomic declaration of `cy_atomic_int`.

Moreover, the `cy_atomic_int` typedefs in `struct_signals.h` was structured in a way that when it is compiled by a C++ compiler in an environment with a C compiler that supports `_Atomic`, it would never use `std::atomic`, which is incorrect and might cause compilation problem when the C++ compiler does not support `_Atomic`. This problem was hidden by the incorrect configuration of `meson.build` above but got surfaced after the `meson.build` fix.

As a context: https://github.com/LLewark/khoca/pull/3