### PR TITLE
Fix release workflow by removing duplicate macos building and migrating to Trusted Publisher

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -35,7 +35,6 @@ jobs:
           - ubuntu-24.04-arm
           - windows-latest
           - windows-11-arm
-          - macos-14
           - macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,8 +53,6 @@ jobs:
     needs: [build_wheels, make_sdist]
     if: 
     runs-on: ubuntu-latest
-    env:
-      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
     permissions:
       id-token: write
       attestations: write
@@ -79,7 +76,5 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
           verbose: true
-        if: env.CAN_DEPLOY == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
The wheel publishing during the release failed since the macos wheels were built twice, and then the `download-artificat` action produced garbage (see eg https://github.com/scikit-build/scikit-build-core/issues/696).
This is fixed by only building on the latest macos arm (we could probably also produce wheels for macos intel, but since this platform is discontinued and wheels are not super important for cysignals anyway, I don't see much value in doing this).

Moreover, I've removed the discouraged user & password auth for publishing. This means however that Trusted Publishing has to be setup:

A new Trusted Publisher for the currently running publishing workflow can be created by accessing the following link(s) while logged-in as an owner of the package(s):
- https://pypi.org/manage/project/cysignals/settings/publishing/?provider=github&owner=sagemath&repository=cysignals&workflow_filename=dist.yml

(see also https://docs.pypi.org/trusted-publishers/adding-a-publisher/)