### PR TITLE
Remove preliminary_late_includes_cy28 directive

### DIFF
--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -852,7 +852,7 @@ dienow:
 /*
  * Set message, return 0 if we need to cysetjmp(), return 1 otherwise.
  */
-static int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, CYTHON_UNUSED int line)
+static inline int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, CYTHON_UNUSED int line)
 {
     cysigs.s = message;
 #if ENABLE_DEBUG_CYSIGNALS
@@ -884,7 +884,7 @@ static int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, C
  * Process the return value of cysetjmp().
  * Return 0 if there was an exception, 1 otherwise.
  */
-static int _sig_on_postjmp(int jmpret)
+static inline int _sig_on_postjmp(int jmpret)
 {
     if (unlikely(jmpret > 0))
     {
@@ -913,7 +913,7 @@ static int _sig_on_postjmp(int jmpret)
 /*
  * Implementation of sig_off().
  */
-static void _sig_off_(const char* file, int line)
+static inline void _sig_off_(const char* file, int line)
 {
 #if ENABLE_DEBUG_CYSIGNALS
     if (cysigs.debug_level >= 4)
@@ -934,7 +934,7 @@ static void _sig_off_(const char* file, int line)
 }
 
 
-static void _sig_unblock_(void)
+static inline void _sig_unblock_(void)
 {
 #if ENABLE_DEBUG_CYSIGNALS
     if (cysigs.block_sigint < 1)
@@ -976,7 +976,7 @@ static void _sig_error_(void)
 }
 
 
-static int _set_debug_level(int level)
+static inline int _set_debug_level(int level)
 {
 #if ENABLE_DEBUG_CYSIGNALS
     int old = cysigs.debug_level;

--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -29,6 +29,7 @@ Interrupt and signal handling for Cython
 
 
 #include "config.h"
+#include <Python.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -52,7 +53,6 @@ Interrupt and signal handling for Cython
 #if HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
-#include <Python.h>
 
 // Custom signal handling of other packages.
 #define MAX_N_CUSTOM_HANDLERS 16
@@ -824,7 +824,172 @@ dienow:
     exit(128 + sig);
 }
 
-/* Finally include the macros and inline functions for use in
- * signals.pyx. These require some of the above functions, therefore
- * this include must come at the end of this file. */
+/**********************************************************************
+ * Functions formerly defined as static inline in macros.h.           *
+ * Moved here so that macros.h contains only #define macros.          *
+ * These are shared across modules via Cython's capsule mechanism.    *
+ **********************************************************************/
+
+/* unlikely() is defined by Cython, but it may not be available yet
+ * when implementation.c is processed (early include). */
+#ifndef unlikely
+#ifdef __GNUC__
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define unlikely(x) (x)
+#endif
+#endif
+
+/* proc_raise is defined in macros.h, but may not be included yet */
+#ifndef proc_raise
+#if HAVE_KILL
+#define proc_raise(sig)  kill(getpid(), sig)
+#else
+#define proc_raise(sig)  raise(sig)
+#endif
+#endif
+
+/*
+ * Set message, return 0 if we need to cysetjmp(), return 1 otherwise.
+ */
+static int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, CYTHON_UNUSED int line)
+{
+    cysigs.s = message;
+#if ENABLE_DEBUG_CYSIGNALS
+    if (cysigs.debug_level >= 4)
+    {
+        fprintf(stderr, "sig_on (count = %i) at %s:%i\n",
+                (int)cysigs.sig_on_count+1, file, line);
+        fflush(stderr);
+    }
+    if (cysigs.block_sigint && cysigs.sig_on_count <= 0)
+    {
+        fprintf(stderr, "\n*** ERROR *** sig_on() with sig_on_count = %i, block_sigint = %i\n",
+                (int)cysigs.sig_on_count, (int)cysigs.block_sigint);
+        print_backtrace();
+    }
+#endif
+    if (cysigs.sig_on_count > 0)
+    {
+        cysigs.sig_on_count++;
+        return 1;
+    }
+
+    /* At this point, cysigs.sig_on_count == 0 */
+    return 0;
+}
+
+
+/*
+ * Process the return value of cysetjmp().
+ * Return 0 if there was an exception, 1 otherwise.
+ */
+static int _sig_on_postjmp(int jmpret)
+{
+    if (unlikely(jmpret > 0))
+    {
+        /* A signal occurred and we jumped back via longjmp.
+         * jmpret contains the signal number that was passed to siglongjmp. */
+        _do_raise_exception(jmpret);
+        _sig_on_recover();
+        return 0;
+    }
+
+    /* When we are here, it's either the original sig_on() call or we
+     * got here after sig_retry(). */
+    cysigs.sig_on_count = 1;
+
+    /* Check whether we received an interrupt before this point. */
+    if (unlikely(cysigs.interrupt_received))
+    {
+        _sig_on_interrupt_received();
+        return 0;
+    }
+
+    return 1;
+}
+
+
+/*
+ * Implementation of sig_off().
+ */
+static void _sig_off_(const char* file, int line)
+{
+#if ENABLE_DEBUG_CYSIGNALS
+    if (cysigs.debug_level >= 4)
+    {
+        fprintf(stderr, "sig_off (count = %i) at %s:%i\n",
+                (int)cysigs.sig_on_count, file, line);
+        fflush(stderr);
+    }
+#endif
+    if (unlikely(cysigs.sig_on_count <= 0))
+    {
+        _sig_off_warning(file, line);
+    }
+    else
+    {
+        --cysigs.sig_on_count;
+    }
+}
+
+
+static void _sig_unblock_(void)
+{
+#if ENABLE_DEBUG_CYSIGNALS
+    if (cysigs.block_sigint < 1)
+    {
+        fprintf(stderr, "\n*** ERROR *** sig_unblock() with sig_on_count = %i, block_sigint = %i\n",
+                (int)cysigs.sig_on_count, (int)cysigs.block_sigint);
+        print_backtrace();
+    }
+#endif
+    --cysigs.block_sigint;
+
+    if (unlikely(cysigs.interrupt_received))
+        /* Re-raise the signal if we can handle it now */
+        if (cysigs.sig_on_count > 0 && cysigs.block_sigint == 0)
+            proc_raise(cysigs.interrupt_received);
+}
+
+
+static void _sig_retry_(void)
+{
+    /* If we're outside of sig_on(), we can't jump, so we can only bail
+     * out */
+    if (unlikely(cysigs.sig_on_count <= 0))
+    {
+        fprintf(stderr, "sig_retry() without sig_on()\n");
+        proc_raise(SIGABRT);
+    }
+    cylongjmp(cysigs.env, -1);
+}
+
+
+static void _sig_error_(void)
+{
+    if (unlikely(cysigs.sig_on_count <= 0))
+    {
+        fprintf(stderr, "sig_error() without sig_on()\n");
+    }
+    proc_raise(SIGABRT);
+}
+
+
+static int _set_debug_level(int level)
+{
+#if ENABLE_DEBUG_CYSIGNALS
+    int old = cysigs.debug_level;
+    cysigs.debug_level = level;
+    return old;
+#else
+    if (level == 0)
+        return 0;    /* 0 is the only valid debug level */
+    else
+        return -1;   /* Error */
+#endif
+}
+
+
+/* Finally include the macros for use in signals.pyx. */
 #include "macros.h"

--- a/src/cysignals/macros.h
+++ b/src/cysignals/macros.h
@@ -55,7 +55,7 @@ extern "C" {
 
 
 /**********************************************************************
- * HELPER FUNCTIONS                                                   *
+ * HELPER MACROS                                                      *
  **********************************************************************/
 
 /* Send a signal to the calling process. The POSIX raise() function
@@ -105,111 +105,18 @@ extern "C" {
  * That's why we need this hackish macro.  We use the fact that || is
  * a short-circuiting operator (the second argument is only evaluated
  * if the first returns 0).
+ *
+ * All helper functions (_sig_on_prejmp, _sig_on_postjmp, _sig_off_,
+ * etc.) are defined in implementation.c and shared across modules via
+ * Cython's capsule mechanism.  Since macros are expanded at the call
+ * site (after capsule declarations), all symbols are available.
  */
 
 #define _sig_on_(message) ( unlikely(_sig_on_prejmp(message, __FILE__, __LINE__)) || _sig_on_postjmp(cysetjmp(cysigs.env)) )
 
-/*
- * Set message, return 0 if we need to cysetjmp(), return 1 otherwise.
- */
-static inline int _sig_on_prejmp(const char* message, CYTHON_UNUSED const char* file, CYTHON_UNUSED int line)
-{
-    cysigs.s = message;
-#if ENABLE_DEBUG_CYSIGNALS
-    if (cysigs.debug_level >= 4)
-    {
-        fprintf(stderr, "sig_on (count = %i) at %s:%i\n",
-                (int)cysigs.sig_on_count+1, file, line);
-        fflush(stderr);
-    }
-    if (cysigs.block_sigint && cysigs.sig_on_count <= 0)
-    {
-        fprintf(stderr, "\n*** ERROR *** sig_on() with sig_on_count = %i, block_sigint = %i\n",
-                (int)cysigs.sig_on_count, (int)cysigs.block_sigint);
-        print_backtrace();
-    }
-#endif
-    if (cysigs.sig_on_count > 0)
-    {
-        cysigs.sig_on_count++;
-        return 1;
-    }
-
-    /* At this point, cysigs.sig_on_count == 0 */
-    return 0;
-}
-
-
-/*
- * Process the return value of cysetjmp().
- * Return 0 if there was an exception, 1 otherwise.
- *
- * This function propagates the signal number naturally via jmpret
- * (the return value from sigsetjmp/cylongjmp), which is always nonzero
- * when a signal occurs. This avoids using global state and eliminates
- * potential desynchronization between the jump return value and any
- * stored signal number.
- */
-static inline int _sig_on_postjmp(int jmpret)
-{
-    if (unlikely(jmpret > 0))
-    {
-        /* A signal occurred and we jumped back via longjmp.
-         * jmpret contains the signal number that was passed to siglongjmp.
-         * Now we're back in a safe context (not in signal handler),
-         * so it's safe to call Python code to raise the exception. */
-        _do_raise_exception(jmpret);
-        _sig_on_recover();
-        return 0;
-    }
-
-    /* When we are here, it's either the original sig_on() call or we
-     * got here after sig_retry(). */
-    cysigs.sig_on_count = 1;
-
-    /* Check whether we received an interrupt before this point.
-     * cysigs.interrupt_received can only be set by the interrupt
-     * handler if cysigs.sig_on_count is zero.  Because of that and
-     * because cysigs.sig_on_count and cysigs.interrupt_received are
-     * volatile, we can safely evaluate cysigs.interrupt_received here
-     * without race conditions. */
-    if (unlikely(cysigs.interrupt_received))
-    {
-        _sig_on_interrupt_received();
-        return 0;
-    }
-
-    return 1;
-}
-
-
-/*
- * Implementation of sig_off().  Applications should not use this
- * directly, use sig_off() instead.
- */
-static inline void _sig_off_(const char* file, int line)
-{
-#if ENABLE_DEBUG_CYSIGNALS
-    if (cysigs.debug_level >= 4)
-    {
-        fprintf(stderr, "sig_off (count = %i) at %s:%i\n",
-                (int)cysigs.sig_on_count, file, line);
-        fflush(stderr);
-    }
-#endif
-    if (unlikely(cysigs.sig_on_count <= 0))
-    {
-        _sig_off_warning(file, line);
-    }
-    else
-    {
-        --cysigs.sig_on_count;
-    }
-}
-
 
 /**********************************************************************
- * USER MACROS/FUNCTIONS                                              *
+ * USER MACROS                                                        *
  **********************************************************************/
 
 /* The actual macros which should be used in a program. */
@@ -223,17 +130,9 @@ static inline void _sig_off_(const char* file, int line)
  *
  * OUTPUT: zero if an interrupt occurred, non-zero otherwise.
  */
-static inline int sig_check(void)
-{
-    if (unlikely(cysigs.interrupt_received) && cysigs.sig_on_count == 0)
-    {
-        _sig_on_interrupt_received();
-        return 0;
-    }
-
-    return 1;
-}
-
+#define sig_check() \
+    ((unlikely(cysigs.interrupt_received) && cysigs.sig_on_count == 0) ? \
+     (_sig_on_interrupt_received(), 0) : 1)
 
 /*
  * Temporarily block interrupts from happening inside sig_on().  This
@@ -253,75 +152,19 @@ static inline int sig_check(void)
  *   sig_block().
  *   A deeper nesting (sig_on(); sig_block(); sig_on();) is OK.
  */
-static inline void sig_block(void)
-{
-    /* This increment may not be atomic. However, that's not an issue
-     * because our signal handlers do not change this value. The value
-     * of block_sigint is set to 0 in _sig_on_recover, but that only
-     * happens after a longjmp(). */
-    ++cysigs.block_sigint;
-}
+#define sig_block() ((void)(++cysigs.block_sigint))
 
-static inline void sig_unblock(void)
-{
-#if ENABLE_DEBUG_CYSIGNALS
-    if (cysigs.block_sigint < 1)
-    {
-        fprintf(stderr, "\n*** ERROR *** sig_unblock() with sig_on_count = %i, block_sigint = %i\n",
-                (int)cysigs.sig_on_count, (int)cysigs.block_sigint);
-        print_backtrace();
-    }
-#endif
-    --cysigs.block_sigint;
-
-    if (unlikely(cysigs.interrupt_received))
-        /* Re-raise the signal if we can handle it now */
-        if (cysigs.sig_on_count > 0 && cysigs.block_sigint == 0)
-            proc_raise(cysigs.interrupt_received);
-}
-
+#define sig_unblock() _sig_unblock_()
 
 /*
  * Retry a failed computation starting from sig_on().
  */
-static inline void sig_retry(void)
-{
-    /* If we're outside of sig_on(), we can't jump, so we can only bail
-     * out */
-    if (unlikely(cysigs.sig_on_count <= 0))
-    {
-        fprintf(stderr, "sig_retry() without sig_on()\n");
-        proc_raise(SIGABRT);
-    }
-    cylongjmp(cysigs.env, -1);
-}
+#define sig_retry() _sig_retry_()
 
 /* Used in error callbacks from C code (in particular NTL and PARI).
  * This should be used after an exception has been raised to jump back
  * to sig_on() where the exception will be seen. */
-static inline void sig_error(void)
-{
-    if (unlikely(cysigs.sig_on_count <= 0))
-    {
-        fprintf(stderr, "sig_error() without sig_on()\n");
-    }
-    proc_raise(SIGABRT);
-}
-
-
-static inline int _set_debug_level(int level)
-{
-#if ENABLE_DEBUG_CYSIGNALS
-    int old = cysigs.debug_level;
-    cysigs.debug_level = level;
-    return old;
-#else
-    if (level == 0)
-        return 0;    /* 0 is the only valid debug level */
-    else
-        return -1;   /* Error */
-#endif
-}
+#define sig_error() _sig_error_()
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/src/cysignals/signals.pxd
+++ b/src/cysignals/signals.pxd
@@ -1,4 +1,3 @@
-# cython: preliminary_late_includes_cy28=True
 #*****************************************************************************
 #  cysignals is free software: you can redistribute it and/or modify it
 #  under the terms of the GNU Lesser General Public License as published
@@ -32,6 +31,9 @@ cdef extern from "struct_signals.h":
 
 
 cdef extern from "macros.h" nogil:
+    # These are all macros defined in macros.h.
+    # The macros expand at the C call site, where capsule symbols
+    # (cysigs, _sig_on_prejmp, etc.) are already declared.
     int sig_on() except 0
     int sig_str(const char*) except 0
     int sig_check() except 0
@@ -84,9 +86,11 @@ cdef inline PyObject* sig_occurred() noexcept:
     return cysigs.exc_value
 
 
-# Variables and functions which are implemented in implementation.c
-# and used by macros.h. We use the Cython cimport mechanism to make
-# these available to every Cython module cimporting this file.
+# Variables and functions which are implemented in implementation.c.
+# We use the Cython capsule mechanism to make these available to every
+# Cython module cimporting this file.  The capsule mechanism provides
+# #define / function pointers that are resolved at import time, so no
+# linking against signals.so is needed.
 cdef nogil:
     cysigs_t cysigs "cysigs"
     void _sig_on_interrupt_received "_sig_on_interrupt_received"() noexcept
@@ -94,6 +98,17 @@ cdef nogil:
     void _do_raise_exception "_do_raise_exception"(int sig) noexcept
     void _sig_off_warning "_sig_off_warning"(const char*, int) noexcept
     void print_backtrace "print_backtrace"() noexcept
+
+    # Former inline functions from macros.h, now regular functions
+    # in implementation.c.  Shared via capsules so the macros in
+    # macros.h can call them at the expansion site.
+    int _sig_on_prejmp "_sig_on_prejmp"(const char*, const char*, int) noexcept
+    int _sig_on_postjmp "_sig_on_postjmp"(int) noexcept
+    void _sig_off_ "_sig_off_"(const char*, int) noexcept
+    void _sig_unblock_ "_sig_unblock_"() noexcept
+    void _sig_retry_ "_sig_retry_"() noexcept
+    void _sig_error_ "_sig_error_"() noexcept
+    int _set_debug_level "_set_debug_level"(int) noexcept
 
 
 cdef inline void __generate_declarations() noexcept:
@@ -103,3 +118,10 @@ cdef inline void __generate_declarations() noexcept:
     _do_raise_exception
     _sig_off_warning
     print_backtrace
+    _sig_on_prejmp
+    _sig_on_postjmp
+    _sig_off_
+    _sig_unblock_
+    _sig_retry_
+    _sig_error_
+    _set_debug_level

--- a/src/cysignals/signals.pxd
+++ b/src/cysignals/signals.pxd
@@ -99,9 +99,9 @@ cdef nogil:
     void _sig_off_warning "_sig_off_warning"(const char*, int) noexcept
     void print_backtrace "print_backtrace"() noexcept
 
-    # Former inline functions from macros.h, now regular functions
-    # in implementation.c.  Shared via capsules so the macros in
-    # macros.h can call them at the expansion site.
+    # Former inline functions from macros.h, now helper functions
+    # defined in implementation.c.  Shared via capsules so the macros
+    # in macros.h can call them at the expansion site.
     int _sig_on_prejmp "_sig_on_prejmp"(const char*, const char*, int) noexcept
     int _sig_on_postjmp "_sig_on_postjmp"(int) noexcept
     void _sig_off_ "_sig_off_"(const char*, int) noexcept

--- a/src/cysignals/signals.pyx
+++ b/src/cysignals/signals.pyx
@@ -1,5 +1,4 @@
 # cython: freethreading_compatible = True
-# cython: preliminary_late_includes_cy28=True
 r"""
 Interrupt and signal handling
 
@@ -59,6 +58,14 @@ cdef extern from "implementation.c":
     void _sig_on_recover() nogil
     void _do_raise_exception(int sig) nogil
     void _sig_off_warning(const char*, int) nogil
+
+    # Former inline functions from macros.h, now in implementation.c
+    int _sig_on_prejmp(const char*, const char*, int) nogil
+    int _sig_on_postjmp(int) nogil
+    void _sig_off_(const char*, int) nogil
+    void _sig_unblock_() nogil
+    void _sig_retry_() nogil
+    void _sig_error_() nogil
 
     # Python library functions for raising exceptions without "except"
     # clause.

--- a/src/cysignals/tests.pyx
+++ b/src/cysignals/tests.pyx
@@ -1,5 +1,5 @@
 # cython: freethreading_compatible = True
-# cython: preliminary_late_includes_cy28=True, show_performance_hints=False
+# cython: show_performance_hints=False
 """
 Test interrupt and signal handling
 

--- a/src/cysignals/tests_helper.c
+++ b/src/cysignals/tests_helper.c
@@ -139,9 +139,6 @@ static void signals_after_delay(int signum, long ms, long interval, int n)
         /* New process group to prevent us getting the signals. */
         setpgid(0,0);
 
-        /* Unblock SIGINT (to fix a warning when testing sig_block()) */
-        cysigs.block_sigint = 0;
-
         /* Make sure SIGTERM simply terminates the process */
         signal(SIGTERM, SIG_DFL);
 


### PR DESCRIPTION
Move all static inline functions from macros.h to implementation.c and replace them with #define macros. Since macros are text templates that expand at the call site (where Cython's capsule declarations are available), this eliminates the need for late includes entirely.

The capsule mechanism shares the implementation.c functions across all importing modules without requiring any linking — this works on all platforms (Linux, macOS, Windows).

Changes:
- macros.h: Remove all static inline functions; keep only #define macros (sig_on, sig_str, sig_off, sig_check, sig_block, sig_unblock, sig_retry, sig_error)
- implementation.c: Add former inline functions as static functions (_sig_on_prejmp, _sig_on_postjmp, _sig_off_, _sig_unblock_, _sig_retry_, _sig_error_, _set_debug_level)
- signals.pxd: Remove directive; add new functions to capsule block
- signals.pyx: Remove directive; add new function declarations
- tests.pyx: Remove directive
- tests_helper.c: Remove direct cysigs reference (not needed in fork child process)