### PR TITLE
Fix -Wunterminated-string-initialization warning in ulong_to_str

### DIFF
--- a/src/cysignals/implementation.c
+++ b/src/cysignals/implementation.c
@@ -160,7 +160,7 @@ static inline void print_stderr(const char* s)
 /* str should have enough space allocated */
 static inline void ulong_to_str(unsigned long val, char *str, int base)
 {
-    const char xdigits[16] = "0123456789abcdef";
+    const char xdigits[16] = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
     unsigned long aux;
     int len;
 


### PR DESCRIPTION
Replace string literal with explicit char array initializer to avoid the -Wunterminated-string-initialization warning from GCC15.
fix
```
[8/15] Compiling C object src/cys...ated_src_cysignals_signals.pyx.c.o
In file included from src/cysignals/signals.cpython-314-x86_64-linux-gnu.so.p/src/cysignals/signals.pyx.c:1133:
../../src/cysignals/implementation.c: In function ‘ulong_to_str’:
../../src/cysignals/implementation.c:163:30: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (17 chars into 16 available) [-Wunterminated-string-initialization]
  163 |     const char xdigits[16] = "0123456789abcdef";
      |                              ^~~~~~~~~~~~~~~~~~
```